### PR TITLE
Functionality for a list of namespaces for operators

### DIFF
--- a/site/templates/subsciptions.yaml
+++ b/site/templates/subsciptions.yaml
@@ -1,0 +1,40 @@
+{{- range .Values.site.subscriptions }}
+{{- $subs := . }}
+{{- $installPlanValue := .installPlanApproval }}
+
+{{- if $subs.namespaces }}
+{{- range .namespaces }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ $subs.name }}
+  namespace: {{ default "openshift-operators" . }}
+spec:
+  name: {{ $subs.name }}
+  source: {{ default "redhat-operators" $subs.source }}
+  sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
+  channel: {{ default "stable" $subs.channel }}
+  installPlanApproval: {{ coalesce $installPlanValue $.Values.global.options.installPlanApproval }}
+  {{- if $.Values.global.options.useCSV }}
+  startingCSV: {{ $subs.csv }}
+  {{- end }}
+---
+{{- end }}
+{{- else }}
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ $subs.name }}
+  namespace: {{ default "openshift-operators" $subs.namespace }}
+spec:
+  name: {{ $subs.name }}
+  source: {{ default "redhat-operators" $subs.source }}
+  sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
+  channel: {{ default "stable" $subs.channel }}
+  installPlanApproval: {{ coalesce  $installPlanValue $.Values.global.options.installPlanApproval }}
+  {{- if $.Values.global.options.useCSV }}
+  startingCSV: {{ $subs.csv }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Adding functionality to list namespaces in the **subcriptions:** section of the values-datacenter.yaml or values-factory.yaml/

Example:  
  # TODO: Allow namespace to be a list
  - name: amq-streams
    namespaces:
      - manuela-data-lake-central-kafka-cluster
      - manuela-tst-all
    channel: amq-streams-1.7.x
    csv: amqstreams.v1.7.1

or 
 - name: advanced-cluster-management
   namespace:  open-cluster-management
   channel: release-2.3
   csv: advanced-cluster-management.v2.3.2
