### PR TITLE
Adds the if control to force booleans to be string type for argo

### DIFF
--- a/site/templates/applications.yaml
+++ b/site/templates/applications.yaml
@@ -40,6 +40,9 @@ spec:
         {{- range .overrides }}
         - name: {{ .name }}
           value: {{ .value }}
+        {{- if .forceString }}
+          forceString: true
+        {{- end }}
         {{- end }}
     {{- end }}
   {{- if .ignoreDifferences }}


### PR DESCRIPTION
argocd errors out on sync because the values for the overrides are boolean vs boolean strings.