### PR TITLE
Make sure that argo can manage cluster-wide resources from the relevant namespaces

### DIFF
--- a/install/templates/argocd/subscription.yaml
+++ b/install/templates/argocd/subscription.yaml
@@ -12,6 +12,10 @@ spec:
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+        value: {{ .Release.Name }}-{{ .Values.main.clusterGroupName }},openshift-gitops
 {{- if .Values.main.options.useCSV }}
   startingCSV: openshift-gitops-operator.{{ .Values.main.gitops.csv }}
 {{- end }}


### PR DESCRIPTION
Otherwise we can error out with:

  Cluster level ClusterRoleBinding vault-server-binding cannot be managed
  when in namespaced mode

By setting ARGOCD_CLUSTER_CONFIG_NAMESPACES to the namespaces where
argocd instance is installed we allow it to create cluster wide
resources for all namespaces.

Tested this and now I am correctly able to invoke the vault helm chart
from argo without the above error.

References:
- https://github.com/argoproj/argo-cd/issues/5886
- https://github.com/argoproj-labs/argocd-operator/issues/385
