### PR TITLE
Add Hub cluster domain as a global variable based on ingress config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ NAME=$(shell basename `pwd`)
 TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%:[a-z].*@%@%' -e 's%:%/%' -e 's%git@%https://%' )
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spec.domain})
 
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set main.options.bootstrap=$(BOOTSTRAP)
+HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set main.options.bootstrap=$(BOOTSTRAP) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
 TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set main.options.bootstrap=$(BOOTSTRAP) --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace"
 PATTERN_OPTS=-f common/examples/values-example.yaml
 

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -55,6 +55,8 @@ spec:
                         value: {{ $.Values.global.pattern }}
                       - name: global.valuesDirectoryURL
                         value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
+                      - name: global.hubClusterDomain
+                        value: {{ .Values.global.hubClusterDomain }}
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -37,6 +37,8 @@ spec:
           value: {{ $.Values.global.pattern }}
         - name: global.valuesDirectoryURL
           value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
+        - name: global.hubClusterDomain
+          value: {{ $.Values.global.hubClusterDomain }}
         {{- range .overrides }}
         - name: {{ .name }}
           value: {{ .value }}

--- a/clustergroup/templates/argocd.yaml
+++ b/clustergroup/templates/argocd.yaml
@@ -24,6 +24,7 @@ spec:
     --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
     --set global.namespace=$ARGOCD_APP_NAMESPACE
     --set global.pattern={{ .Values.global.pattern }}
+    --set global.hubClusterDomain={{ .Values.global.hubClusterDomain }}
     --set global.valuesDirectoryURL={{ .Values.global.valuesDirectoryURL }}
     --post-renderer ./kustomize\"]
     \ \n"

--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -30,6 +30,8 @@ spec:
           value: {{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}
         - name: global.pattern
           value: {{ .Release.Name }}
+        - name: global.hubClusterDomain
+          value: {{ .Values.global.hubClusterDomain }}
 {{- if eq .Values.main.options.syncPolicy "Automatic" }}
   syncPolicy:
     automated: {}


### PR DESCRIPTION
Retrieves hub cluster from configured ingress.cluster and injects it as a variable for applications to use.  This is important for services that might need to be accessed via explicit routes on the hub cluster.

We can't take this approach with managed clusters since we won't know how many there will be and we can't know when applying the template which one we're rendering for.  (We are hoping that ACM templating can help with this.)

Full credit to @mbaldessari for the approach and implementation - my only contribution here is camel-casing the variable name and making it explicitly "hub" cluster.