### PR TITLE
Vault PKI initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 values-secret.yaml
 .*-expected.yaml
 pattern-vault.init
+vault.init

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ uninstall:
 
 vault-init:
 	common/scripts/vault-utils.sh vault_init common/pattern-vault.init
+	common/scripts/vault-utils.sh vault_pki_init common/pattern-vault.init
 
 vault-unseal:
 	common/scripts/vault-utils.sh vault_unseal common/pattern-vault.init

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 
 # Assumptions - vault in the demo will be running in non-HA mode so there will only be a vault-0
 # vault will be running in the "vault" namespace
@@ -90,6 +90,16 @@ vault_get_root_token()
 
 	token=`grep "Initial Root Token" $file | awk '{ print $4 }'`
 	echo -n $token
+}
+
+vault_token_exec()
+{
+	file="$1"
+	token=`vault_get_root_token $file`
+	shift
+	cmd="$@"
+
+	oc -n vault exec vault-0 -- bash -c "VAULT_TOKEN=$token $cmd"
 }
 
 $@

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -112,7 +112,14 @@ oc_get_domain()
 
 oc_get_pki_domain()
 {
-	basedomain=`oc_get_domain | cut -d. -f3-`
+	echo -n `oc_get_domain | cut -d. -f3-`
+}
+
+oc_get_pki_role()
+{
+	pkidomain=`oc_get_pki_domain`
+	certrole=`echo $pkidomain | sed 's|\.|_|g'`
+	echo -n $certrole
 }
 
 vault_pki_init()
@@ -121,14 +128,14 @@ vault_pki_init()
 	token=`vault_get_root_token $file`
 	shift
 
-	pkidomain=`oc_get_pki_domain`
-	certrole=`sed -e 's|\.|_|g' $pkidomain`
+	pkidomain=`oc_get_pki_role`
+	pkirole=`oc_get_pki_role`
 
 	vault_token_exec $file "vault secrets enable pki"
 	vault_token_exec $file "vault secrets tune --max-lease=8760h pki"
 	vault_token_exec $file "vault write pki/root/generate/internal common_name=$pkidomain ttl=8760h"
 	vault_token_exec $file 'vault write pki/config/urls issuing_certificates="http://127.0.0.1:8200/v1/pki/ca" crl_distribution_points="http://127.0.0.1:8200/v1/pki/crl"'
-	vault_token_exec $file "vault write pki/roles/$certrole allowed_domains=$pkidomain allow_subdomains=true max_ttl=8760h"
+	vault_token_exec $file "vault write pki/roles/$pkirole allowed_domains=$pkidomain allow_subdomains=true max_ttl=8760h"
 }
 
 $@

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -78,4 +78,18 @@ vault_init()
 	vault_unseal $file
 }
 
+vault_get_root_token()
+{
+	# Argument is expected to be the text output of the vault operator init command which includes Unseal Keys
+	# (5 by default) and a root token.
+	if [ -n "$1" ]; then
+		file=$1
+	else
+		file=common/vault.init
+	fi
+
+	token=`grep "Initial Root Token" $file | awk '{ print $4 }'`
+	echo -n $token
+}
+
 $@


### PR DESCRIPTION
The makefile and scripts now know how to initialize a vault PKI for the DNS domain that is the parent of the hub cluster's domain.  (For example, the PKI for apps.mhjacks-mcgo-hub.blueprints.rhecoeng.com is created for blueprints.rhecoeng.com).