### PR TITLE
Protect ourselves from wrong origin repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ init:
 	git submodule update --init --recursive
 
 deploy:
+# Protect ourselves from the mistake of having origin point at https:///github.com/..., origin must point to our own clone
+ifeq ($(findstring https///,$(TARGET_REPO)),https///)
+	@echo "ERROR origin points to wrong repo $(TARGET_REPO)"
+	exit 1
+endif
 	helm install $(NAME) common/install/ $(HELM_OPTS)
 
 upgrade:


### PR DESCRIPTION
When origin is set to the upstream repo we end up pointing to a non
existing repo:

  --set main.git.repoURL="https///github.com/hybrid-cloud-patterns/multicloud-gitops.git"

Let's add some code to protect us from this mistake. So when origin
points to the upstream repo and not our own copy:
$ git remote -v
michele git@github.com:mbaldessari/multicloud-gitops.git (fetch)
michele git@github.com:mbaldessari/multicloud-gitops.git (push)
origin  https://github.com/hybrid-cloud-patterns/multicloud-gitops.git (fetch)
origin  https://github.com/hybrid-cloud-patterns/multicloud-gitops.git (push)

We error out sufficiently early:
$ make install
make -f common/Makefile deploy
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
ERROR origin points to wrong repo https///github.com/hybrid-cloud-patterns/multicloud-gitops.git
exit 1
make[1]: *** [common/Makefile:43: deploy] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:7: deploy] Error 2
