### PR TITLE
Add variable qualification to prevent helm template errors

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -56,7 +56,7 @@ spec:
                       - name: global.valuesDirectoryURL
                         value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
                       - name: global.hubClusterDomain
-                        value: {{ .Values.global.hubClusterDomain }}
+                        value: {{ $.Values.global.hubClusterDomain }}
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}


### PR DESCRIPTION
This would cause ACM to error out on bootstrap with an ugly helm template error