### PR TITLE
Don't conditionalize lookups when we know we need them

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -58,11 +58,7 @@ spec:
                       - name: global.hubClusterDomain
                         value: {{ $.Values.global.hubClusterDomain }}
                       - name: global.localClusterDomain
-                      {{- if $.Values.clusterGroup.isHubCluster }}
-                        value: {{ $.Values.global.hubClusterDomain }}
-                      {{- else }}
                         value: '{{ `{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}` }}'
-                      {{- end }}
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}


### PR DESCRIPTION
I believe the previous conditional created a situation where the conditional would always evaluate to "true", since the template would only render on the hub cluster where the variable was set to true.