### PR TITLE
Remove description due to regression in GitOps 1.4.0

### DIFF
--- a/clustergroup/templates/projects.yaml
+++ b/clustergroup/templates/projects.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ . }}
   namespace: {{ $.Values.global.pattern }}-{{ $.Values.clusterGroup.name }}
 spec:
-  description: "Pattern {{ . }}"
   destinations:
   - namespace: '*'
     server: '*'


### PR DESCRIPTION
Remove description as this is not allowed in GitOps 1.4.0.  Expect it back in 1.4.1 but this will unblock development and demos we need to do this week.