### PR TITLE
Remove bashism in vault_exec

### DIFF
--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -121,7 +121,7 @@ vault_exec()
 	shift
 	cmd="$@"
 
-	oc -n vault exec -i vault-0 -- bash -c "$cmd"
+	oc -n vault exec -i vault-0 -- sh -c "$cmd"
 }
 
 vault_login()


### PR DESCRIPTION
We currently uase "bash -c" inside vault_exec. This only works when
using UBI-based images. Let's move to 'sh -c' to be a bit more robust
in case we're in the presence of the upstream vault images which do not
have bash installed.

Tested a 'vault-init' on UBI images and it correctly worked with no
errors whatsoever in the log.
