### PR TITLE
Add namespace support to the regional gitops installations

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -42,6 +42,10 @@ spec:
                   name: openshift-gitops-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
+                  config:
+                    env:
+                      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+                        value: "*"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
This allows argo on regional clusters to have more rights.
Specifically this is needed to create the clusterbindingrole needed
for the k8s-external-secret operator.

As a first pass we'll use the '*' namespace. In a second iteration
we'll need to look at restricting that to openshift-gitops and the
namespace of the regional gitops instance. At this point of time
such a change is too invasive and is at risk of breaking existing
patterns.

Tested this on multicloud gitops and I correctly get argo to create
the clusterrolebinding in the k8s-external-secret:

  $ oc get clusterrolebinding | grep k8s-extern
  k8s-external-secrets-kubernetes-external-secrets          ClusterRole/k8s-external-secrets-kubernetes-external-secrets
  k8s-external-secrets-kubernetes-external-secrets-auth     ClusterRole/system:auth-delegator

Previously this would fail with:
  Cluster level CustomResourceDefinition "externalsecrets.kubernetes-client.io" can not be managed when in namespaced mode
