### PR TITLE
Improvements for common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,16 @@ test:
 # Test the charts as the pattern would drive them
 	@for t in $(CHARTS); do common/scripts/test.sh $$t normal "$(TEST_OPTS) $(PATTERN_OPTS)"; if [ $$? != 0 ]; then exit 1; fi; done
 
+validate-origin:
+	git ls-remote $(TARGET_REPO)
+
 init:
 	git submodule update --init --recursive
 
-deploy:
+deploy: validate-origin
 	helm install $(NAME) common/install/ $(HELM_OPTS)
 
-upgrade:
+upgrade: validate-origin
 	helm upgrade $(NAME) common/install/ $(HELM_OPTS)
 
 uninstall:

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -40,11 +40,7 @@ spec:
         - name: global.hubClusterDomain
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain
-        {{- if $.Values.clusterGroup.isHubCluster }}
-          value: {{ $.Values.global.hubClusterDomain }}
-        {{- else }}
-          value: {{ $.Values.global.localClusterDomain }}
-        {{- end }}
+          value: {{ coalesce $.Values.global.localClusterDomain $.Values.global.hubClusterDomain }}
         {{- range .overrides }}
         - name: {{ .name }}
           value: {{ .value | quote }}

--- a/clustergroup/templates/argocd.yaml
+++ b/clustergroup/templates/argocd.yaml
@@ -25,6 +25,7 @@ spec:
     --set global.namespace=$ARGOCD_APP_NAMESPACE
     --set global.pattern={{ .Values.global.pattern }}
     --set global.hubClusterDomain={{ .Values.global.hubClusterDomain }}
+    --set global.localClusterDomain={{ coalesce .Values.global.localClusterDomain .Values.global.hubClusterDomain }}
     --set global.valuesDirectoryURL={{ .Values.global.valuesDirectoryURL }}
     --post-renderer ./kustomize\"]
     \ \n"


### PR DESCRIPTION
1) Introduce coalesce-based method to populate global.localClusterDomain variable.  This will work with either the helm-based app approach or helm-with-kustomize.  The intent is to check localClusterDomain and if it is not set (as we expect it not to be on a hub cluster; since we don't do the ACM lookup on hub clusters), set it to the global.hubClusterDomain value instead.  This should ensure that localClusterDomain can be used on both regional and hub clusters and will do the right thing regardless.

2) Introduce "validate-origin" target in makefile to list origin and make sure configured credentials can reach it - make install and upgrade dependent on it
