### PR TITLE
Add conditional hub-certificate-authority template to push HUB CA to managed clusters

### DIFF
--- a/acm/templates/policies/hub-certificate-authority.yaml
+++ b/acm/templates/policies/hub-certificate-authority.yaml
@@ -1,0 +1,78 @@
+# We only push the hub CA to the regional clusters when the user explicitely tells us so
+# This template fetches "ca.crt" from the "kube-root-ca.crt" configMap from the hub
+# (this configmap is present in all namespaces) and puts it in the vault-ca secret inside
+# the k8s-external-secrets namespace so the external-secrets pod knows how to trust
+# the https://vault-vault.apps.hub-domain... endpoint
+{{- if .Values.pushHubCA }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: hub-certificate-authority-policy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: hub-certificate-authority
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: k8s-external-secrets
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Secret
+                metadata:
+                  name: vault-ca
+                  namespace: k8s-external-secrets
+                data:
+                  ca.crt: '{{ `{{hub fromConfigMap "" "kube-root-ca.crt" "ca.crt" | base64enc hub}}` }}'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: hub-certificate-authority-placement-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: hub-certificate-authority-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: hub-certificate-authority-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: hub-certificate-authority-placement
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
+{{- end }}

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -8,3 +8,4 @@ global:
 clusterGroup:
   managedClusterGroups:
 
+pushHubCA: false


### PR DESCRIPTION
By default this ACM templates is inactive and will only be activated if
asked explicitely via the .pushHubCA parameter.
It will pull the ca.crt field from the the kube-root-ca.crt ConfigMap on
the hub into a secret on the managed cluster. This will then be used
by the external-secrets pod so it can trust the https://vault-vault.apps.hub-domain...
API endpoint of the vault.

Tested with this change and once enabled via .pushHubCA the
kubernetes-external-secrets pod could correctly connect to the vault
running on the HUB (without this we'd get self-signed certs errors)
