### PR TITLE
Fix the TARGET_REPO calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BOOTSTRAP=1
 SECRETS=~/values-secret.yaml
 NAME=$(shell basename `pwd`)
-TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%:[a-z].*@%@%' -e 's%:%/%' -e 's%git@%https://%' )
+# This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
+# This is because we expect to use tokens for repo authentication as opposed to SSH keys
+TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%^git@%%' -e 's%^https://%%' -e 's%:%/%' -e 's%^%https://%')
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spec.domain})


### PR DESCRIPTION
The repo would sometimes come out as `https///`.  With this new routine, the URL prefix is removed earlier in the process and re-added as `https://` at the very end of the sed pipeline