### PR TITLE
Changes to vault-utils to support vault/external-secrets combo

### DIFF
--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -13,7 +13,6 @@ vault_ready_check()
 {
 #NAME                                   READY   STATUS    RESTARTS   AGE
 #vault-0                                1/1     Running   0          44m
-#vault-agent-injector-8d9cfcd47-skklw   1/1     Running   0          121m
 	oc get po -n vault | grep vault-0 | awk '{ print $2, $3 }' 2>/dev/null
 }
 
@@ -70,6 +69,12 @@ vault_init()
 
 	# The vault is ready to be initialized when it is "Running" but not "ready".  Unsealing it makes it ready
 	rdy_check=`get_vault_ready`
+
+	if [ "$rdy_check" = "1/1 Running" ]; then
+		echo "Vault is already ready, exiting"
+		exit 0
+	fi
+
 	until [ "$rdy_check" = "0/1 Running" ]
 	do
 		echo $rdy_check
@@ -81,10 +86,13 @@ vault_init()
 	vault_unseal $file
 	vault_login $file
 
-	vault_pki_init $file
-	vault_kubernetes_init $file
 	vault_secrets_init $file
+	vault_kubernetes_init $file
 	vault_policy_init $file
+
+	# Do not need pki init by default
+	# But this is how you could call it if you need it
+	#vault_pki_init $file
 }
 
 # Retrieves the root token specified in the file $1
@@ -169,23 +177,25 @@ vault_kubernetes_init()
 {
 	file="$1"
 
-	vault_token=$(oc sa get-token -n vault vault)
-	k8s_host='kubernetes_host=https://$KUBERNETES_PORT_443_TCP_ADDR:443'
-
-	vault_exec $file "vault auth enable kubernetes"
-	vault_exec $file "vault write auth/kubernetes/config token_reviewer_jwt=$vault_token $k8s_host kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt issuer=https://kubernetes.default.svc"
+	vault_exec $file "vault auth enable --path=hub kubernetes"
 }
 
 vault_policy_init()
 {
 	file="$1"
 
-	vault_exec $file 'vault policy write hub-policy - << EOF
-path "secret/*"
-  { capabilities = ["read"]
+	k8s_host='https://$KUBERNETES_PORT_443_TCP_ADDR:443'
+	secret_name="$(oc get -n k8s-external-secrets serviceaccount k8s-external-secrets-kubernetes-external-secrets -o jsonpath='{.secrets}' | jq -r '.[] | select(.name | test ("k8s-external-secrets-kubernetes-external-secrets-token-")).name')"
+	sa_token="$(oc get secret -n k8s-external-secrets ${secret_name} -o go-template='{{ .data.token | base64decode }}')"
+
+	vault_exec $file "vault write auth/hub/config token_reviewer_jwt=$sa_token kubernetes_host=$k8s_host kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt issuer=https://kubernetes.default.svc"
+	vault_exec $file 'vault policy write hub-secret - << EOF
+path "secret/data/hub/*"
+  { capabilities = ["create", "read", "update", "delete", "list"]
 }
 EOF
 '
+	vault_exec $file 'vault write auth/hub/role/hub-role bound_service_account_names="k8s-external-secrets-kubernetes-external-secrets" bound_service_account_namespaces="k8s-external-secrets"  policies="default,hub-secret" ttl="15m"'
 }
 
 vault_secrets_init()


### PR DESCRIPTION
This will change vault-init to initialize a secret container in hub and set it up for use by external secrets