### PR TITLE
Rename the namespace and serviceaccounts to the name of the new golang-based external secrets operator

### DIFF
--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -185,8 +185,8 @@ vault_policy_init()
 	file="$1"
 
 	k8s_host='https://$KUBERNETES_PORT_443_TCP_ADDR:443'
-	secret_name="$(oc get -n k8s-external-secrets serviceaccount k8s-external-secrets-kubernetes-external-secrets -o jsonpath='{.secrets}' | jq -r '.[] | select(.name | test ("k8s-external-secrets-kubernetes-external-secrets-token-")).name')"
-	sa_token="$(oc get secret -n k8s-external-secrets ${secret_name} -o go-template='{{ .data.token | base64decode }}')"
+	secret_name="$(oc get -n golang-external-secrets serviceaccount golang-external-secrets -o jsonpath='{.secrets}' | jq -r '.[] | select(.name | test ("golang-external-secrets-token-")).name')"
+	sa_token="$(oc get secret -n golang-external-secrets ${secret_name} -o go-template='{{ .data.token | base64decode }}')"
 
 	vault_exec $file "vault write auth/hub/config token_reviewer_jwt=$sa_token kubernetes_host=$k8s_host kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt issuer=https://kubernetes.default.svc"
 	vault_exec $file 'vault policy write hub-secret - << EOF
@@ -195,7 +195,7 @@ path "secret/data/hub/*"
 }
 EOF
 '
-	vault_exec $file 'vault write auth/hub/role/hub-role bound_service_account_names="k8s-external-secrets-kubernetes-external-secrets" bound_service_account_namespaces="k8s-external-secrets"  policies="default,hub-secret" ttl="15m"'
+	vault_exec $file 'vault write auth/hub/role/hub-role bound_service_account_names="golang-external-secrets" bound_service_account_namespaces="golang-external-secrets" policies="default,hub-secret" ttl="15m"'
 }
 
 vault_secrets_init()


### PR DESCRIPTION
We're moving to the newer golang-based external secrets operator at https://external-secrets.io/
To be more explicit about our intention we name namespaces and
serviceaccounts golang-external-secrets. Let's rename it in the hub
config as well.

Tested with the other related golang changes and everything worked as
expected.
