### PR TITLE
Run shellcheck on all shell scripts in scripts/

### DIFF
--- a/examples/kustomize-renderer/kustomize
+++ b/examples/kustomize-renderer/kustomize
@@ -1,14 +1,14 @@
 #!/bin/bash -x
 
-BASE=`dirname $0`
-if [ $BASE = $PWD ]; then 
+BASE=$(dirname $0)
+if [ "$BASE" = "$PWD" ]; then
     BASE=./
 fi
 
 cat <&0 > "$BASE/helm.patch.yaml"
 
 # Including at least one log to stderr allows us to see the full -x output
-echo $HOME $PWD 1>&2
+echo "$HOME" "$PWD" 1>&2
 ls -al  1>&2
 
 kubectl kustomize "$BASE" && rm "$BASE/helm.patch.yaml" 

--- a/examples/kustomize-renderer/kustomize
+++ b/examples/kustomize-renderer/kustomize
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-BASE=$(dirname $0)
+BASE=$(dirname "$0")
 if [ "$BASE" = "$PWD" ]; then
     BASE=./
 fi

--- a/scripts/secret.sh
+++ b/scripts/secret.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# shellcheck disable=SC2181
+# shellcheck disable=SC2181,SC3037
 # SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?
+# SC3037 (warning): In POSIX sh, echo flags are undefined.
 
 #This script must receive arguments for the following parameters; it is easiest to pass them as environment variables from the command line.
 #Example values from the first use for it, in industrial-edge

--- a/scripts/secret.sh
+++ b/scripts/secret.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# shellcheck disable=SC2181
+# SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?
 
 #This script must receive arguments for the following parameters; it is easiest to pass them as environment variables from the command line.
 #Example values from the first use for it, in industrial-edge

--- a/scripts/secret.sh
+++ b/scripts/secret.sh
@@ -42,6 +42,6 @@ while true; do
 done
 
 user=$(echo admin | base64)
-password=$(echo $pw | base64)
+password=$(echo "$pw" | base64)
 
 echo "{ \"apiVersion\": \"v1\", \"kind\": \"Secret\", \"metadata\": { \"name\": \"$SECRET_NAME\", \"namespace\": \"$TARGET_NAMESPACE\" }, \"data\": { \"ARGOCD_PASSWORD\": \"$password\", \"ARGOCD_USERNAME\": \"$user\" }, \"type\": \"Opaque\" }" | oc apply -f-

--- a/scripts/secret.sh
+++ b/scripts/secret.sh
@@ -16,30 +16,23 @@
 passwd_resource="secrets/${COMPONENT}-gitops-cluster"
 src_ns="${PATTERN}-${COMPONENT}"
 
-ns=0
-gitops=0
-
 # Check for Namespaces and Secrets to be ready (it takes the cluster a few minutes to deploy them)
 while true; do
 	echo -n "Checking for namespace $TARGET_NAMESPACE to exist..."
 	if oc get namespace "$TARGET_NAMESPACE" >/dev/null 2>/dev/null; then
 		echo "not yet"
-		ns=0
 		sleep 2
 		continue
 	else
 		echo "OK"
-		ns=1
 	fi
 
 	echo -n "Checking for $passwd_resource to be populated in $src_ns..."
 	pw=$(oc -n "$src_ns" extract "$passwd_resource" --to=- 2>/dev/null)
 	if [ "$?" = 0 ] && [ -n "$pw" ]; then
 		echo "OK"
-		gitops=1
 	else
 		echo "not yet"
-		gitops=0
 		sleep 2
 		continue
 	fi

--- a/scripts/secret.sh
+++ b/scripts/secret.sh
@@ -18,9 +18,9 @@ ns=0
 gitops=0
 
 # Check for Namespaces and Secrets to be ready (it takes the cluster a few minutes to deploy them)
-while [ 1 ] ; do
+while true; do
 	echo -n "Checking for namespace $TARGET_NAMESPACE to exist..."
-	if [ oc get namespace $TARGET_NAMESPACE >/dev/null 2>/dev/null ]; then
+	if oc get namespace "$TARGET_NAMESPACE" >/dev/null 2>/dev/null; then
 		echo "not yet"
 		ns=0
 		sleep 2
@@ -31,7 +31,7 @@ while [ 1 ] ; do
 	fi
 
 	echo -n "Checking for $passwd_resource to be populated in $src_ns..."
-	pw=`oc -n $src_ns extract $passwd_resource --to=- 2>/dev/null`
+	pw=$(oc -n "$src_ns" extract "$passwd_resource" --to=- 2>/dev/null)
 	if [ "$?" = 0 ] && [ -n "$pw" ]; then
 		echo "OK"
 		gitops=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 target=$1
-name=$(echo $1 | sed -e s@/@-@g -e s@charts-@@)
+name=$(echo "$1" | sed -e s@/@-@g -e s@charts-@@)
 TEST_VARIANT="$2"
 CHART_OPTS="$3"
 
@@ -11,26 +11,26 @@ OUTPUT=${TESTDIR}/.${name}-${TEST_VARIANT}.expected.yaml
 #OUTPUT=${TESTDIR}/.${name}.expected.yaml
 
 echo "Testing $1 chart (${TEST_VARIANT})" >&2
-helm template $target --name-template $name ${CHART_OPTS} > ${OUTPUT}
+helm template "${target}" --name-template "${name}" "${CHART_OPTS}" > "${OUTPUT}"
 #cp ${OUTPUT} ${REFERENCE}
-if [ ! -e ${REFERENCE} ]; then
-    touch ${REFERENCE}
+if [ ! -e "${REFERENCE}" ]; then
+    touch "${REFERENCE}"
 fi
-diff -u ${REFERENCE}  ${OUTPUT}
+diff -u "${REFERENCE}" "${OUTPUT}"
 rc=$?
-if [ $rc = 0 ]; then
-    rm -f ${OUTPUT}
+if [ "$rc" = 0 ]; then
+    rm -f "${OUTPUT}"
 fi
 
-if [ $TEST_VARIANT = normal -a $rc = 0 ]; then
+if [ "$TEST_VARIANT" = normal -a "$rc" = 0 ]; then
     # Another method of finding variables missing from values.yaml, eg.
     # -    name: -datacenter
     # +    name: pattern-name-datacenter
     # Alas we can't make it fatal because there *should* be some differences
-    diff -u ${TESTDIR}/${name}-naked.expected.yaml ${TESTDIR}/${name}-normal.expected.yaml
+    diff -u "${TESTDIR}/${name}-naked.expected.yaml" "${TESTDIR}/${name}-normal.expected.yaml"
 fi
 
-if [ $rc = 0 ]; then
+if [ "$rc" = 0 ]; then
 	echo "PASS on $target $TEST_VARIANT with opts [$CHART_OPTS]"
 else
 	echo "FAIL on $target $TEST_VARIANT with opts [$CHART_OPTS]"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ if [ "$rc" = 0 ]; then
     rm -f "${OUTPUT}"
 fi
 
-if [ "$TEST_VARIANT" = normal -a "$rc" = 0 ]; then
+if [ "$TEST_VARIANT" = normal ] && [ "$rc" = 0 ]; then
     # Another method of finding variables missing from values.yaml, eg.
     # -    name: -datacenter
     # +    name: pattern-name-datacenter

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -184,6 +184,7 @@ vault_policy_init()
 {
 	file="$1"
 
+	# shellcheck disable=SC2016
 	k8s_host='https://$KUBERNETES_PORT_443_TCP_ADDR:443'
 	secret_name="$(oc get -n golang-external-secrets serviceaccount golang-external-secrets -o jsonpath='{.secrets}' | jq -r '.[] | select(.name | test ("golang-external-secrets-token-")).name')"
 	sa_token="$(oc get secret -n golang-external-secrets "${secret_name}" -o go-template='{{ .data.token | base64decode }}')"

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -44,7 +44,7 @@ vault_unseal()
 		file=common/vault.init
 	fi
 
-	for unseal in $(grep "Unseal Key" "$file" | awk '{ print $4 }')
+	grep "Unseal Key" < "$file" | awk '{ print $4 }' | while IFS= read -r unseal
 	do
 		oc -n vault exec vault-0 -- vault operator unseal "$unseal"
 	done


### PR DESCRIPTION
A bunch of changes to get shellcheck to not complain on common/ too much.

Currently I have only tested that make vault-init kept working

﻿- Fix bash linting issues
- Fix quoting issue in examples/kustomize-renderer/kustomize
- Fix some shellcheck issues in scripts/secret.sh
- Disable SC2181 shellcheck test
- Drop unused ns and gitops vars
- Quote password var
- Fix a bunch of quoting in scripts/test.sh
- Disable SC3037 in scripts/secret.sh
- Fix SC2166 in scripts/test.sh
- Shellcheck fixes for scripts/vault-token.sh
- Fix most shellcheck warnings in vault-utils.sh
- Disable SC2016 as we know what we're doing
- Fix SC2013: To read lines rather than words, pipe/redirect to a 'while read' loop in vault-utils
