### PR TITLE
Remove submodule's init target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,6 @@ helmlint:
 validate-origin:
 	git ls-remote $(TARGET_REPO)
 
-init:
-	git submodule update --init --recursive
-
 deploy: validate-origin
 	helm install $(NAME) common/install/ $(HELM_OPTS)
 


### PR DESCRIPTION
Common is not a submodule any longer. No point in keeping this around
