### PR TITLE
Add a make help target to list all existing targets (common)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,49 +13,54 @@ HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_R
 TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set main.options.bootstrap=$(BOOTSTRAP) --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
+
+.PHONY: help
+help: ## This help message
+	@printf "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)\n"
+
 #  Makefiles that use this target must provide:
 #  	PATTERN: The name of the pattern that is using it.  This will be used programmatically for the source namespace
 #  	TARGET_NAMESPACE: target namespace to install the secret into
 #  	COMPONENT: The component of the target namespace.  In industrial edge, factory or datacenter - and for the secret
 #  		it needs to be datacenter because that's where the CI components run.
 #  	SECRET_NAME: The name of the secret to manage
-argosecret:
+argosecret: ## creates the argo secret
 	PATTERN="$(PATTERN)" TARGET_NAMESPACE="$(TARGET_NAMESPACE)" COMPONENT="$(COMPONENT)" SECRET_NAME="$(SECRET_NAME)" common/scripts/secret.sh
 
 #  Makefiles in the individual patterns should call these targets explicitly
 #  e.g. from industrial-edge: make -f common/Makefile show
-show:
+show: ## show the starting template without installing it
 	helm template common/install/ --name-template $(NAME) $(HELM_OPTS)
 
 CHARTS=$(shell find . -type f -iname 'Chart.yaml' -exec dirname "{}"  \; | sed -e 's/.\///')
-test:
+test: ## run helm tests
 # Test that all values used by the chart are in values.yaml with the same defaults as the pattern
 	@for t in $(CHARTS); do common/scripts/test.sh $$t naked ""; if [ $$? != 0 ]; then exit 1; fi; done
 # Test the charts as the pattern would drive them
 	@for t in $(CHARTS); do common/scripts/test.sh $$t normal "$(TEST_OPTS) $(PATTERN_OPTS)"; if [ $$? != 0 ]; then exit 1; fi; done
 
-helmlint:
+helmlint: ## run helm lint
 	@for t in $(CHARTS); do helm lint $(TEST_OPTS) $(PATTERN_OPTS) $$t; if [ $$? != 0 ]; then exit 1; fi; done
 
-validate-origin:
+validate-origin: ## verify the git origin is available
 	git ls-remote $(TARGET_REPO)
 
-deploy: validate-origin
+deploy: validate-origin ## deploys the pattern
 	helm install $(NAME) common/install/ $(HELM_OPTS)
 
-upgrade: validate-origin
+upgrade: validate-origin ## runs helm upgrade
 	helm upgrade $(NAME) common/install/ $(HELM_OPTS)
 
-uninstall:
+uninstall: ## runs helm uninstall
 	helm uninstall $(NAME)
 
-vault-init:
+vault-init: ## inits, unseals and configured the vault
 	common/scripts/vault-utils.sh vault_init common/pattern-vault.init
 
-vault-unseal:
+vault-unseal: ## unseals the vault
 	common/scripts/vault-utils.sh vault_unseal common/pattern-vault.init
 
-load-secrets:
+load-secrets: ## loads the secrets into the vault
 	common/scripts/ansible-push-vault-secrets.sh
 
 .phony: install test


### PR DESCRIPTION
This improves the UX discoverability
This will give the following output when run from inside common:

  $ make help
  help             This help message
  argosecret       creates the argo secret
  show             show the starting template without installing it
  test             run helm tests
  helmlint         run helm lint
  validate-origin  verify the git origin is available
  deploy           deploys the pattern
  upgrade          runs helm upgrade
  uninstall        runs helm uninstall
  vault-init       inits, unseals and configured the vault
  vault-unseal     unseals the vault
  load-secrets     loads the secrets into the vault

Tested on Linux (bash+zsh) and on Mac OSX (bash+zsh)
