### PR TITLE
Allow overriding the remote name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SECRETS=~/values-secret.yaml
 NAME=$(shell basename `pwd`)
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
 # This is because we expect to use tokens for repo authentication as opposed to SSH keys
-TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%^git@%%' -e 's%^https://%%' -e 's%:%/%' -e 's%^%https://%')
+TARGET_ORIGIN ?= origin
+TARGET_REPO=$(shell git remote show $(TARGET_ORIGIN) | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%^git@%%' -e 's%^https://%%' -e 's%:%/%' -e 's%^%https://%')
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spec.domain})


### PR DESCRIPTION
Currently we hard-code origin as the remote to use for git.
Allow the user to override this via TARGET_ORIGIN variable (which
defaults to 'origin' like before)

Tested with:
make upgrade
make TARGET_ORIGIN=fork upgrade

And the commands used the 'origin' remote and the 'fork' one
respectively.

Reason for this is that I hate calling my forks 'origin' and I rarely
even have an 'origin' remote. I call my remotes 'fork' so I do not push
branches upstream accidentally.
