### PR TITLE
Move to kubeconform

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,10 +56,9 @@ jobs:
         run: |
           make helmlint
 
-      - name: Run make helm kubeval
+      - name: Run make helm kubeconform
         run: |
-          curl -L -O https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
-          tar xf kubeval-linux-amd64.tar.gz
-          sudo mv -v kubeval /usr/local/bin
-          helm plugin install https://github.com/instrumenta/helm-kubeval
-          make kubeval
+          curl -L -O https://github.com/yannh/kubeconform/releases/download/v0.4.13/kubeconform-linux-amd64.tar.gz
+          tar xf kubeconform-linux-amd64.tar.gz
+          sudo mv -v kubeconform /usr/local/bin
+          make kubeconform

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,10 @@ test: ## run helm tests
 helmlint: ## run helm lint
 	@for t in $(CHARTS); do helm lint $(TEST_OPTS) $(PATTERN_OPTS) $$t; if [ $$? != 0 ]; then exit 1; fi; done
 
-kubeval: ## run helm kubeval
-	@for t in $(CHARTS); do helm kubeval --ignore-missing-schemas $$t; if [ $$? != 0 ]; then exit 1; fi; done
+API_URL ?= https://raw.githubusercontent.com/hybrid-cloud-patterns/ocp-schemas/main/openshift/4.9/
+# We need to skip 'CustomResourceDefinition' as openapi2jsonschema seems to be unable to generate them ATM
+kubeconform: ## run helm kubeconform
+	@for t in $(CHARTS); do helm template $(TEST_OPTS) $(PATTERN_OPTS) $$t | kubeconform -strict -skip 'CustomResourceDefinition' -verbose -schema-location $(API_URL); if [ $$? != 0 ]; then exit 1; fi; done
 
 validate-origin: ## verify the git origin is available
 	git ls-remote $(TARGET_REPO)


### PR DESCRIPTION
Note that this depends on the generated static files that
we push out into our ocp-schemas repo.
Example CI run:
stdin - PlacementBinding edge-placement-binding is valid
stdin - PlacementBinding openshift-gitops-placement-binding is valid
stdin - PlacementRule edge-placement is valid
stdin - PlacementRule openshift-gitops-placement is valid
stdin - MultiClusterHub multiclusterhub is valid
stdin - Policy openshift-gitops-policy is valid
stdin - Policy edge-clustergroup-policy is valid
stdin - ConfigMap environment is valid
stdin - clustersecretstores.external-secrets.io CustomResourceDefinition skipped
stdin - externalsecrets.external-secrets.io CustomResourceDefinition skipped
stdin - secretstores.external-secrets.io CustomResourceDefinition skipped
stdin - ClusterRole release-name-external-secrets-view is valid
stdin - ClusterRole release-name-external-secrets-controller is valid
stdin - ClusterRole release-name-external-secrets-edit is valid
stdin - ServiceAccount release-name-external-secrets is valid
stdin - Role release-name-external-secrets-leaderelection is valid
stdin - ClusterRoleBinding release-name-external-secrets-controller is valid
stdin - ClusterRoleBinding role-tokenreview-binding is valid
stdin - RoleBinding release-name-external-secrets-leaderelection is valid
stdin - ClusterSecretStore vault-backend is valid
stdin - Deployment release-name-external-secrets is valid
stdin - Namespace openshift-gitops is valid
stdin - Subscription openshift-gitops-operator is valid
stdin - Application release-name-example is valid
stdin - ClusterRoleBinding openshift-gitops-cluster-admin-rolebinding is valid
stdin - ClusterRoleBinding mypattern-example-cluster-admin-rolebinding is valid
stdin - Namespace mypattern-example is valid
stdin - Namespace application-ci is valid
stdin - Namespace open-cluster-management is valid
stdin - Application acm is valid
stdin - Application pipelines is valid
stdin - AppProject datacenter is valid
stdin - OperatorGroup application-ci-operator-group is valid
stdin - OperatorGroup open-cluster-management-operator-group is valid
stdin - ArgoCD example-gitops is valid
stdin - Subscription openshift-pipelines-operator-rh is valid
stdin - Subscription advanced-cluster-management is valid
