### PR TITLE
Bring in some change that was missed

### DIFF
--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -8,10 +8,7 @@ global:
 
 clusterGroup:
   name: example
-
-  proposedOptions:
-    manageGitops: True
-    isHubCluster: True
+  isHubCluster: true
 
 #  managedClusterGroups:
 #  - name: factory


### PR DESCRIPTION
In multicloud-gitops via e5c6fb68 (Remove some obsolete options and add
needed settings for isHubCluster) it was missed to backport the common
hunk to the common/ proper tree.

Fix this so proper common/ and multicloud-gitops/common/ do not differ
at all.
