### PR TITLE
Allow skipped resource types to be customized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,10 @@ helmlint: ## run helm lint
 	@for t in $(CHARTS); do helm lint $(TEST_OPTS) $(PATTERN_OPTS) $$t; if [ $$? != 0 ]; then exit 1; fi; done
 
 API_URL ?= https://raw.githubusercontent.com/hybrid-cloud-patterns/ocp-schemas/main/openshift/4.9/
+KUBECONFORM_SKIP ?= -skip 'CustomResourceDefinition'
 # We need to skip 'CustomResourceDefinition' as openapi2jsonschema seems to be unable to generate them ATM
 kubeconform: ## run helm kubeconform
-	@for t in $(CHARTS); do helm template $(TEST_OPTS) $(PATTERN_OPTS) $$t | kubeconform -strict -skip 'CustomResourceDefinition' -verbose -schema-location $(API_URL); if [ $$? != 0 ]; then exit 1; fi; done
+	@for t in $(CHARTS); do helm template $(TEST_OPTS) $(PATTERN_OPTS) $$t | kubeconform -strict $(KUBECONFORM_SKIP) -verbose -schema-location $(API_URL); if [ $$? != 0 ]; then exit 1; fi; done
 
 validate-origin: ## verify the git origin is available
 	git ls-remote $(TARGET_REPO)


### PR DESCRIPTION
Of course openapi2json is broken with Tekton Pipelines and Tasks, so we
need to be able to skip resources on a per-project basis.
