### PR TITLE
Fix wrong KUBECONFIG fail logic and do not bail out if vault init output already exists

### DIFF
--- a/scripts/ansible-push-vault-secrets.sh
+++ b/scripts/ansible-push-vault-secrets.sh
@@ -32,7 +32,7 @@
   - name: Fail if both KUBECONFIG and ~/.kube/config do not exist
     ansible.builtin.fail:
       msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
-    failed_when: not kubeconfig_result.stat.exists
+    failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
 
   - name: Parse "{{ values_secret }}"
     ansible.builtin.set_fact:

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -63,8 +63,8 @@ vault_init()
 	fi
 
 	if [ -f "$file" ] && grep -q -e '^Unseal' "$file"; then
-		echo "$file already exists and contains seal secrets. If this is what you really wanted, move that file away first or call vault_delete"
-		exit 1
+		echo "$file already exists and contains seal secrets. We're moving it away to ${file}.bak"
+		mv -vf "${file}" "${file}.bak"
 	fi
 
 	# The vault is ready to be initialized when it is "Running" but not "ready".  Unsealing it makes it ready


### PR DESCRIPTION
- Make sure we only bail out when both KUBECONFIG and ~/.kube/config are not set
- Stop bailing out if the vault file exists
