### PR TITLE
Remove the bootstrap concept from common/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BOOTSTRAP=1
 SECRETS=~/values-secret.yaml
 NAME=$(shell basename `pwd`)
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
@@ -10,8 +9,8 @@ TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spec.domain})
 
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set main.options.bootstrap=$(BOOTSTRAP) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set main.options.bootstrap=$(BOOTSTRAP) --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com
+HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
+TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
 

--- a/install/templates/argocd/namespace.yaml
+++ b/install/templates/argocd/namespace.yaml
@@ -1,8 +1,6 @@
 # Pre-create so we can create our argo app for keeping subscriptions in sync
 # Do it here so that we don't try to sync it in the future
-{{- if .Values.main.options.bootstrap }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-gitops
-{{- end }}

--- a/install/templates/argocd/subscription.yaml
+++ b/install/templates/argocd/subscription.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.main.options.bootstrap }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -18,5 +17,4 @@ spec:
         value: {{ .Release.Name }}-{{ .Values.main.clusterGroupName }},openshift-gitops
 {{- if .Values.main.options.useCSV }}
   startingCSV: openshift-gitops-operator.{{ .Values.main.gitops.csv }}
-{{- end }}
 {{- end }}

--- a/install/values.yaml
+++ b/install/values.yaml
@@ -8,7 +8,6 @@ main:
     syncPolicy: Automatic
     installPlanApproval: Automatic
     useCSV: False
-    bootstrap: True
 
   gitops:
     channel: stable


### PR DESCRIPTION
It used to be for deploying multiple patterns. Let's drop it for the
time being: Nowhere do we document how and when to use it anyways.
