### PR TITLE
Improve error message when values-secret.yaml is not formatted as expected

### DIFF
--- a/scripts/ansible-push-vault-secrets.sh
+++ b/scripts/ansible-push-vault-secrets.sh
@@ -48,6 +48,19 @@
     failed_when:
       secrets is not defined or secrets | length == 0
 
+  - name: Check the value-secret.yaml file for errors
+    ansible.builtin.fail:
+      msg: >
+        "{{ item }}" is not properly formatted. Each key under 'secrets:'
+        needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
+    when: >
+      item.key | length == 0 or
+      item.value is not mapping
+    loop:
+      "{{ secrets | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+
   # Detect here if we have only the following two keys under a password
   # s3.accessKey: <accessKey>
   # s3.secretKey: <secret key>


### PR DESCRIPTION
The format we expect is:
secrets:
  group1:
    secret1: value1
    secret2: value2

  group2:
    secret1: value1

This will generate the following vault injections:
vault kv put secret/hub/group1 -> secret1=value1 secret2=value2
vault kv put secret/hub/group2 -> secret1=value1

Now if the file has a format that we do not really recognize, for
example like:
secrets:
  foo: bar
  group1:
    secret1: value1

We will error out as follows:

    TASK [Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case]
    fatal: [localhost]: FAILED! => {"msg": "The conditional check
    '\"s3.accessKey\" in item.value.keys()' failed. The error was: error
    while evaluating conditional (\"s3.accessKey\" in
    item.value.keys()): 'ansible.utils.unsafe_proxy.AnsibleUnsafeText
    object' has no attribute 'keys'\n\nThe error appears to be in
    '/home/michele/Engineering/cloud-patterns/multicloud-gitops/common/scripts/ansible-push-vault-secrets.sh':
    line 56, column 5, but may\nbe elsewhere in the file depending on
    the exact syntax problem.\n\nThe offending line appears to be:\n\n
    # Note: the vars: line is due to
    https://github.com/ansible/ansible/issues/40239\n  - name: Check if
    any of the passwords has only s3.[accessKey,secretKey] and generate
    the combined s3Secret in that case\n    ^ here\n"}

Let's error out more nicely in such a case. With this patch we get:

    TASK [Check the value-secret.yaml file for errors] failed:
    [localhost] (item=foo) => {"ansible_loop_var": "item", "changed":
    false, "item": {"key": "foo", "value": "bar"}, "msg": "\"{'key':
    'foo', 'value': 'bar'}\" is not properly formatted. Each key under
    'secrets:' needs to point to a dictionary of key, value pairs. See
    values-secret.yaml.template.\n"} skipping: [localhost] => (item=aws)

Reported-By: Ilkka Tengvall
