### PR TITLE
ServiceAccount hub-gitops-argocd-dex-server needs more permissions

### DIFF
--- a/clustergroup/templates/argocd-super-role.yaml
+++ b/clustergroup/templates/argocd-super-role.yaml
@@ -35,3 +35,7 @@ subjects:
     # This is the {ArgoCD.name}-argocd-server
     name: {{ .Values.clusterGroup.name }}-gitops-argocd-server
     namespace: {{ $.Values.global.pattern }}-{{ .Values.clusterGroup.name }}
+  # NOTE: This is needed starting with gitops-1.5.0 (see issue common#76)
+  - kind: ServiceAccount
+    name: {{ .Values.clusterGroup.name }}-gitops-argocd-dex-server
+    namespace: {{ $.Values.global.pattern }}-{{ .Values.clusterGroup.name }}

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -51,6 +51,10 @@ subjects:
     # This is the {ArgoCD.name}-argocd-server
     name: example-gitops-argocd-server
     namespace: common-example
+  # NOTE: This is needed starting with gitops-1.5.0 (see issue common#76)
+  - kind: ServiceAccount
+    name: example-gitops-argocd-dex-server
+    namespace: common-example
 ---
 # Source: pattern-clustergroup/templates/argocd.yaml
 apiVersion: argoproj.io/v1alpha1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -71,6 +71,10 @@ subjects:
     # This is the {ArgoCD.name}-argocd-server
     name: example-gitops-argocd-server
     namespace: mypattern-example
+  # NOTE: This is needed starting with gitops-1.5.0 (see issue common#76)
+  - kind: ServiceAccount
+    name: example-gitops-argocd-dex-server
+    namespace: mypattern-example
 ---
 # Source: pattern-clustergroup/templates/projects.yaml
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Since gitops 1.5.0 the secondary argocd instance's web interface is
erroring out with:

    Failed to query provider "https://hub-gitops-server-multicloud-gitops-hub.apps.bandini-dc.blueprints.rhecoeng.com/api/dex":
    Get "http://hub-gitops-dex-server.multicloud-gitops-hub.svc.cluster.local:5556/api/dex/.well-known/openid-configuration":
    dial tcp 172.30.229.125:5556: connect: connection refused

The exact problem is:

    W0421 07:32:56.239809       1 reflector.go:324]
    pkg/mod/k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167:
    failed to list *v1.Secret: secrets is forbidden: User
    "system:serviceaccount:multicloud-gitops-hub:hub-gitops-argocd-dex-server"
    cannot list resource "secrets" in API group "" in the namespace
    "multicloud-gitops-hub" E0421 07:32:56.239838       1
    reflector.go:138]
    pkg/mod/k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167:
    Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is
    forbidden: User
    "system:serviceaccount:multicloud-gitops-hub:hub-gitops-argocd-dex-server"
    cannot list resource "secrets" in API group "" in the namespace
    "multicloud-gitops-hub" W0421 08:14:28.521492       1
    reflector.go:324]
    pkg/mod/k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167:
    failed to list *v1.ConfigMap: configmaps is forbidden: User
    "system:serviceaccount:multicloud-gitops-hub:hub-gitops-argocd-dex-server"
    cannot list resource "configmaps" in API group "" in the namespace
    "multicloud-gitops-hub" E0421 08:14:28.521517       1
    reflector.go:138]
    pkg/mod/k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167:
    Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap:
    configmaps is forbidden: User
    "system:serviceaccount:multicloud-gitops-hub:hub-gitops-argocd-dex-server"
    cannot list resource "configmaps" in API group "" in the namespace
    "multicloud-gitops-hub"

Let's give the 'system:serviceaccount:multicloud-gitops-hub:hub-gitops-argocd-dex-server' user
the same permissions we give hub-gitops-argocd-server and
hub-gitops-argocd-application-controller.

We should try and revisit these permission and try and lessen them. They
are too high currently.

Tested by applying this to a running cluster and the secondary argo
instance was now available through the web interface.

Fixes: https://github.com/hybrid-cloud-patterns/common/issues/76
