### PR TITLE
Remove wrong line in examples/values-secret.yaml

### DIFF
--- a/examples/values-secret.yaml
+++ b/examples/values-secret.yaml
@@ -4,7 +4,6 @@ main:
 
 secrets:
   # NEVER COMMIT THESE VALUES TO GIT
-  enabled: true
   imageregistry:
     # Quay -> Robot Accounts -> Robot Login
     account: test-account


### PR DESCRIPTION
Ilkka mentioned this and it's quite annoying as load-secret will
barf due to the wrong line.

This is just a quick removal to avoid having people hit this issue.
Maybe we should just drop this entirely and have only custom top-level
values-secret.yaml.template files like we do in multicloud-gitops.
