### PR TITLE
WIP Quote key and value when uploading a secret

### DIFF
--- a/scripts/ansible-push-vault-secrets.sh
+++ b/scripts/ansible-push-vault-secrets.sh
@@ -123,7 +123,7 @@
 
   - name: Debug
     debug:
-      msg: "vault kv put {{ vault_path }}/{{ item.key }} -> {{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}"
+      msg: "vault kv put '{{ vault_path }}/{{ item.key }}' -> '{{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}'"
     loop:
       "{{ secrets | dict2items }}"
     loop_control:
@@ -135,7 +135,7 @@
       namespace: "{{ vault_ns }}"
       pod: "{{ vault_pod }}"
       command: |
-        sh -c "vault kv put {{ vault_path }}/{{ item.key }} {{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}"
+        sh -c "vault kv put '{{ vault_path }}/{{ item.key }}' '{{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}'"
     loop:
       "{{ secrets | dict2items }}"
     loop_control:


### PR DESCRIPTION
Currently we break horribly when a user adds a multiline secret in yaml
(via the | operator):

    failed: [localhost] (item=cert-test) => {"ansible_loop_var": "item",
    "changed": true, "item": {"key": "cert-test", "value": {"ca.crt":
    "-----BEGIN CERTIFICATE-----\nMIIEgjCCA
    uqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAzMREwDwYDVQQKDAhDT09M\nLkxBQjEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDEwNTEz\nfoo\nbar\nbaz\n"}},
    "rc": 127, "return_code": 127, "stderr": "Failed to parse K=V data:
    invalid key/value pair \"CERTIFICATE-----\": format must be
    key=value\nsh: line 1:
    MIIEgjCCAuqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAzMREwDwYDVQ QKDAhDT09M:
    command not found\nsh: line 2:
    LkxBQjEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDEwNTEz:
    command not found

Let's try to escape key and value and let the yaml parsers do their job.
Tested with:
    secrets:
      cert-test:
	ca.crt: |
	  -----BEGIN CERTIFICATE-----
	  MIIEgjCCAuqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAzMREwDwYDVQQKDAhDT09M
	  LkxBQjEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDEwNTEz
	  foo
	  bar
	  baz

And got the following:

    $ oc exec -it -n vault vault-0 -- bash -c 'vault kv get secret/hub/cert-test'
    ======= Metadata =======
    Key                Value
    ---                -----
    created_time       2022-04-22T08:36:34.624976106Z
    custom_metadata    <nil>
    deletion_time      n/a
    destroyed          false
    version            2

    ===== Data =====
    Key       Value
    ---       -----
    ca.crt    -----BEGIN CERTIFICATE-----
    MIIEgjCCAuqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAzMREwDwYDVQQKDAhDT09M
    LkxBQjEeMBwGA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIyMDEwNTEz
    foo
    bar
    baz
