### PR TITLE
Remove useless exclude: kube-* from ACM policies

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -20,8 +20,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -21,8 +21,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -68,8 +68,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -100,8 +100,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -182,8 +180,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:


### PR DESCRIPTION
The namespaceSelector example:

  namespaceSelector:
    include: ["default"]
    exclude: ["kube-*"]

shows up in many places in the documentation. Yet it is not particularly
relevant. Full explanation can be found in
https://bugzilla.redhat.com/show_bug.cgi?id=2079393

Let's just drop the exclude, since we already define an include
without a regex, there is no point in excluding anything really.

Tested by redeploying a full multicloud-gitops pattern across
two clusters.
