### PR TITLE
Add a small precheck to make sure python kubernetes is importable

### DIFF
--- a/scripts/ansible-push-vault-secrets.sh
+++ b/scripts/ansible-push-vault-secrets.sh
@@ -13,6 +13,9 @@
     debug: False
 
   tasks:
+  - name: Check if the kubernetes python module is usable from ansible
+    ansible.builtin.shell: "{{ ansible_python_interpreter }} -c 'import kubernetes'"
+
   - name: Check for existence of "{{ values_secret }}"
     ansible.builtin.stat:
       path: "{{ values_secret }}"


### PR DESCRIPTION
As noted by Johnny 'ansible-galaxy collection install community.kubernetes'
does not care about lower-level dependencies whatsoever, so let's check
if the python modules is importable first as the error otherwise is
quite non-obvious.
