### PR TITLE
Fix the TARGET_REPO calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BOOTSTRAP=1
 SECRETS=~/values-secret.yaml
 NAME=$(shell basename `pwd`)
-TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL://' -e 's%:[a-z].*@%@%' -e 's%:%/%' -e 's%git@%https://%' )
+# This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
+# This is because we expect to use tokens for repo authentication as opposed to SSH keys
+TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL:[[:space:]]*//' -e 's%^git@%%' -e 's%^https://%%' -e 's%:%/%' -e 's%^%https://%')
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
(cherry picked from commit 04bd2d5bbc7103be1235fd7df252ddc14f5dca56)

Cherry picked commit to pull into stable-2.0 to resolve issue with rendering git url.

With the current version if I have checked out the following repo:

https://github.com/strangiato/industrial-edge.git

The sed command renders the following with an incorrect `///` instead of `://`

```
https///github.com/strangiato/industrial-edge.git
```

This cherry-pick pulls a fix from main into the stable-2.0 branch which is referenced by the industrial-edge repo to allow for the cloning of http URLs.