### PR TITLE
Add initial support for imperative jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spe
 
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml -f $(SECRETS) --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com
+TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml"
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
 

--- a/clustergroup/templates/imperative/clusterrole.yaml
+++ b/clustergroup/templates/imperative/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.clusterRoleName }}
+rules:
+{{- if $.Values.clusterGroup.imperative.clusterRoleYaml -}}
+  {{ toYaml $.Values.clusterGroup.imperative.clusterRoleYaml | nindent 2 }}
+{{- else }}
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+{{- end }}

--- a/clustergroup/templates/imperative/configmap.yaml
+++ b/clustergroup/templates/imperative/configmap.yaml
@@ -1,0 +1,12 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{- $valuesyaml := toYaml $.Values -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}
+  namespace: {{ $.Values.clusterGroup.imperative.namespace}}
+data:
+  values.yaml: |
+{{ tpl $valuesyaml . | indent 4 }}
+{{ end }}

--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -1,0 +1,87 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.cronJobName }}
+  namespace: {{ $.Values.clusterGroup.imperative.namespace}}
+spec:
+  schedule: {{ $.Values.clusterGroup.imperative.schedule | quote }}
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ $.Values.clusterGroup.imperative.activeDeadlineSeconds }}
+      template:
+        metadata:
+          name: {{ $.Values.clusterGroup.imperative.jobName }}
+        spec:
+          serviceAccountName: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there
+            - name: git-init
+              image: {{ $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- {{ $.Values.global.repoURL }} /git/repo;chmod 0770 /git/{repo,home}"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+    {{- range $.Values.clusterGroup.imperative.jobs }}
+            - name: {{ .name }}
+              image: {{ .image | default $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - {{ .timeout | default "600" | quote }}
+                - ansible-playbook
+                {{- if $.Values.clusterGroup.imperative.verbosity }}
+                - {{ $.Values.clusterGroup.imperative.verbosity }}
+                {{- end }}
+                - -e
+                - "@/values/values.yaml"
+                - {{ .playbook }}
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+              - name: values-volume
+                mountPath: /values/values.yaml
+                subPath: values.yaml
+    {{- end }}
+          containers:
+          - name: {{ $.Values.clusterGroup.imperative.jobName }}-done
+            image: {{ $.Values.clusterGroup.imperative.image }}
+            imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+            command:
+            - 'sh'
+            - '-c'
+            - echo
+            - {{ range $.Values.clusterGroup.imperative.jobs }}{{ .name }}{{ end }}
+            - '\n'
+            volumeMounts:
+            - name: git
+              mountPath: "/git"
+            - name: values-volume
+              mountPath: /values/values.yaml
+              subPath: values.yaml
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}
+          restartPolicy: Never
+{{ end }}

--- a/clustergroup/templates/imperative/namespace.yaml
+++ b/clustergroup/templates/imperative/namespace.yaml
@@ -1,0 +1,10 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: {{ $.Values.clusterGroup.imperative.namespace }}
+    argocd.argoproj.io/managed-by: {{ $.Values.global.pattern }}-{{ $.Values.clusterGroup.name }}
+  name: {{ $.Values.clusterGroup.imperative.namespace }}
+{{ end }}

--- a/clustergroup/templates/imperative/rbac.yaml
+++ b/clustergroup/templates/imperative/rbac.yaml
@@ -1,0 +1,30 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.namespace }}-cluster-admin-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $.Values.clusterGroup.imperative.clusterRoleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+    namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.namespace }}-admin-rolebinding
+  namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Values.clusterGroup.imperative.roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+    namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+{{ end }}

--- a/clustergroup/templates/imperative/role.yaml
+++ b/clustergroup/templates/imperative/role.yaml
@@ -1,0 +1,20 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.roleName }}
+  namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+rules:
+{{- if $.Values.clusterGroup.imperative.roleYaml -}}
+  {{ toYaml $.Values.clusterGroup.imperative.roleYaml | nindent 2 }}
+{{- else }}
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+{{- end }}
+{{- end }}

--- a/clustergroup/templates/imperative/serviceaccount.yaml
+++ b/clustergroup/templates/imperative/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{/* Only define this if there are any imperativejobs defined */}}
+{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{- if $.Values.clusterGroup.imperative.serviceAccountCreate -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+  namespace: {{ $.Values.clusterGroup.imperative.namespace }}
+{{- end }}
+{{- end }}

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -13,16 +13,22 @@ clusterGroup:
 
   imperative:
     jobs: []
-    image: quay.io/hybridcloudpatterns/utility-container:latest
+    # This image contains ansible + kubernetes.core by default and is used to run the jobs
+    image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
     namespace: "imperative"
+    # configmap name in the namespace that will contain all helm values
     valuesConfigMap: "helm-values-configmap"
     cronJobName: "imperative-cronjob"
     jobName: "imperative-job"
     imagePullPolicy: Always
+    # This is the maximum timeout of all the jobs (1h)
     activeDeadlineSeconds: 3600
+    # By default we run this every 10minutes
     schedule: "*/10 * * * *"
+    # Increase ansible verbosity with '-v' or '-vv..'
     verbosity: ""
     serviceAccountCreate: true
+    # service account to be used to run the cron pods
     serviceAccountName: imperative-sa
     clusterRoleName: imperative-cluster-role
     clusterRoleYaml: ""

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -6,9 +6,28 @@ global:
     syncPolicy: Automatic
     installPlanApproval: Automatic
 
+# Note that sometimes changing helm values might require a hard refresh (https://github.com/helm/helm/issues/3486)
 clusterGroup:
   name: example
   isHubCluster: true
+
+  imperative:
+    jobs: []
+    image: quay.io/hybridcloudpatterns/utility-container:latest
+    namespace: "imperative"
+    valuesConfigMap: "helm-values-configmap"
+    cronJobName: "imperative-cronjob"
+    jobName: "imperative-job"
+    imagePullPolicy: Always
+    activeDeadlineSeconds: 3600
+    schedule: "*/10 * * * *"
+    verbosity: ""
+    serviceAccountCreate: true
+    serviceAccountName: imperative-sa
+    clusterRoleName: imperative-cluster-role
+    clusterRoleYaml: ""
+    roleName: imperative-role
+    roleYaml: ""
 
 #  managedClusterGroups:
 #  - name: factory

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -78,7 +78,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: quay.io/hybridcloudpatterns/utility-container:latest
+        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
         imagePullPolicy: Always
         jobName: imperative-job
         jobs:
@@ -280,7 +280,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there
             - name: git-init
-              image: quay.io/hybridcloudpatterns/utility-container:latest
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -293,7 +293,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: test
-              image: quay.io/hybridcloudpatterns/utility-container:latest
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -316,7 +316,7 @@ spec:
                 subPath: values.yaml
           containers:
           - name: imperative-job-done
-            image: quay.io/hybridcloudpatterns/utility-container:latest
+            image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
             imagePullPolicy: Always
             command:
             - 'sh'

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -12,6 +12,15 @@ metadata:
   name: mypattern-example
 spec: {}
 ---
+# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: imperative
+    argocd.argoproj.io/managed-by: mypattern-example
+  name: imperative
+---
 # Source: pattern-clustergroup/templates/namespaces.yaml
 apiVersion: v1
 kind: Namespace
@@ -31,6 +40,136 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-example
   name: application-ci
 spec:
+---
+# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imperative-sa
+  namespace: imperative
+---
+# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-values-configmap
+  namespace: imperative
+data:
+  values.yaml: |
+    clusterGroup:
+      applications:
+        acm:
+          ignoreDifferences:
+          - group: internal.open-cluster-management.io
+            jsonPointers:
+            - /spec/loggingCA
+            kind: ManagedClusterInfo
+          name: acm
+          namespace: open-cluster-management
+          path: common/acm
+          project: datacenter
+        pipe:
+          name: pipelines
+          namespace: application-ci
+          path: charts/datacenter/pipelines
+          project: datacenter
+      imperative:
+        activeDeadlineSeconds: 3600
+        clusterRoleName: imperative-cluster-role
+        clusterRoleYaml: ""
+        cronJobName: imperative-cronjob
+        image: quay.io/hybridcloudpatterns/utility-container:latest
+        imagePullPolicy: Always
+        jobName: imperative-job
+        jobs:
+        - name: test
+          playbook: ansible/test.yml
+        namespace: imperative
+        roleName: imperative-role
+        roleYaml: ""
+        schedule: '*/10 * * * *'
+        serviceAccountCreate: true
+        serviceAccountName: imperative-sa
+        valuesConfigMap: helm-values-configmap
+        verbosity: ""
+      isHubCluster: true
+      managedClusterGroups:
+      - clusterSelector:
+          matchExpressions:
+          - key: vendor
+            operator: In
+            values:
+            - OpenShift
+        helmOverrides:
+        - name: clusterGroup.isHubCluster
+          value: "false"
+        name: edge
+        targetRevision: main
+      name: example
+      namespaces:
+      - open-cluster-management
+      - application-ci
+      projects:
+      - datacenter
+      subscriptions:
+        acm:
+          channel: release-2.4
+          csv: advanced-cluster-management.v2.4.1
+          name: advanced-cluster-management
+          namespace: open-cluster-management
+        odh:
+          csv: opendatahub-operator.v1.1.0
+          disabled: true
+          name: opendatahub-operator
+          source: community-operators
+        pipelines:
+          csv: redhat-openshift-pipelines.v1.5.2
+          name: openshift-pipelines-operator-rh
+    global:
+      git:
+        account: hybrid-cloud-patterns
+        dev_revision: main
+        email: someone@somewhere.com
+        hostname: github.com
+      hubClusterDomain: hub.example.com
+      localClusterDomain: region.example.com
+      namespace: pattern-namespace
+      options:
+        installPlanApproval: Automatic
+        syncPolicy: Automatic
+        useCSV: false
+      pattern: mypattern
+      repoURL: https://github.com/pattern-clone/mypattern
+      valuesDirectoryURL: https://github.com/pattern-clone/mypattern/raw/main
+    main:
+      clusterGroupName: example
+      git:
+        repoURL: https://github.com/pattern-clone/mypattern
+        revision: main
+    secrets:
+      aws:
+        s3Secret: test-secret
+      git:
+        token: test-git-token
+        username: test-user
+      imageregistry:
+        account: test-account
+        token: test-quay-token
+---
+# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imperative-cluster-role
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: pattern-clustergroup/templates/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
@@ -75,6 +214,129 @@ subjects:
   - kind: ServiceAccount
     name: example-gitops-argocd-dex-server
     namespace: mypattern-example
+---
+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: imperative-cluster-admin-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: imperative-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: imperative-sa
+    namespace: imperative
+---
+# Source: pattern-clustergroup/templates/imperative/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: imperative-role
+  namespace: imperative
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+---
+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: imperative-admin-rolebinding
+  namespace: imperative
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: imperative-role
+subjects:
+  - kind: ServiceAccount
+    name: imperative-sa
+    namespace: imperative
+---
+# Source: pattern-clustergroup/templates/imperative/job.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: imperative-cronjob
+  namespace: imperative
+spec:
+  schedule: "*/10 * * * *"
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: imperative-job
+        spec:
+          serviceAccountName: imperative-sa
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there
+            - name: git-init
+              image: quay.io/hybridcloudpatterns/utility-container:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch  --depth 1 -- https://github.com/pattern-clone/mypattern /git/repo;chmod 0770 /git/{repo,home}"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+            - name: test
+              image: quay.io/hybridcloudpatterns/utility-container:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - "600"
+                - ansible-playbook
+                - -e
+                - "@/values/values.yaml"
+                - ansible/test.yml
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+              - name: values-volume
+                mountPath: /values/values.yaml
+                subPath: values.yaml
+          containers:
+          - name: imperative-job-done
+            image: quay.io/hybridcloudpatterns/utility-container:latest
+            imagePullPolicy: Always
+            command:
+            - 'sh'
+            - '-c'
+            - echo
+            - test
+            - '\n'
+            volumeMounts:
+            - name: git
+              mountPath: "/git"
+            - name: values-volume
+              mountPath: /values/values.yaml
+              subPath: values.yaml
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: helm-values-configmap
+          restartPolicy: Never
 ---
 # Source: pattern-clustergroup/templates/subscriptions.yaml
 ---


### PR DESCRIPTION
This creates a CronJob (by default runs every 10mins) which will run
all the playbooks listed in imperativeJobs: in a values-*.yaml file.
The jobs will be run sequentially and need to be idempotent.
They are currently using a rhel9-ubi container with ansible and some
additional tools in them.
