### PR TITLE
Change all ACM policies' severity definition

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -18,7 +18,7 @@ spec:
           name: {{ .name }}-clustergroup-config
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -19,7 +19,7 @@ spec:
           name: openshift-gitops-config
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -66,7 +66,7 @@ spec:
           name: openshift-gitops-config
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -98,7 +98,7 @@ spec:
           name: edge-clustergroup-config
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default
@@ -178,7 +178,7 @@ spec:
           name: openshift-gitops-config
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default


### PR DESCRIPTION
The error with ACM 2.5 is the following:
  Failed to create policy template
  ConfigurationPolicy.policy.open-cluster-management.io
  "config-demo-secret" is invalid: spec.severity: Unsupported value:
  "med": supported values: "low", "Low", "medium", "Medium", "high",
  "High", "critical", "Critical"

Use "medium" as severity. Tested with ACM 2.5 and the policies come up
correctly.
