### PR TITLE
Improve installation resilience for vault

### DIFF
--- a/scripts/ansible-push-vault-secrets.sh
+++ b/scripts/ansible-push-vault-secrets.sh
@@ -95,6 +95,9 @@
       name: "{{ vault_ns }}"
     register: vault_ns_rc
     failed_when: vault_ns_rc.resources | length == 0
+    until: vault_ns_rc is success
+    retries: 30
+    delay: 5
     when: not debug | bool
 
   - name: Check if the vault pod is present

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -62,17 +62,17 @@ vault_init()
 		file=common/vault.init
 	fi
 
-	if [ -f "$file" ] && grep -q -e '^Unseal' "$file"; then
-		echo "$file already exists and contains seal secrets. We're moving it away to ${file}.bak"
-		mv -vf "${file}" "${file}.bak"
-	fi
-
 	# The vault is ready to be initialized when it is "Running" but not "ready".  Unsealing it makes it ready
 	rdy_check=`get_vault_ready`
 
 	if [ "$rdy_check" = "1/1 Running" ]; then
 		echo "Vault is already ready, exiting"
 		exit 0
+	fi
+
+	if [ -f "$file" ] && grep -q -e '^Unseal' "$file"; then
+		echo "$file already exists and contains seal secrets. We're moving it away to ${file}.bak"
+		mv -vf "${file}" "${file}.bak"
 	fi
 
 	until [ "$rdy_check" = "0/1 Running" ]


### PR DESCRIPTION
1) Sometimes vault namespace does not show up for query when ansible-push-vault-secrets is running. This adds retry logic to give it a few tries before erroring out.

2) Move the rename of the pattern-vault.init (password file) until after the first check for vault readiness. This enables us to run make vault-init idempotently (that is - make vault-init will exit successfully if there's a currently running and correctly configured vault)