### PR TITLE
Switch to external-secrets.io/v1beta1 for the clusterstore

### DIFF
--- a/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: vault-backend

--- a/tests/golang-external-secrets-naked.expected.yaml
+++ b/tests/golang-external-secrets-naked.expected.yaml
@@ -5697,7 +5697,7 @@ spec:
           secretName: golang-external-secrets-webhook
 ---
 # Source: golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: vault-backend

--- a/tests/golang-external-secrets-normal.expected.yaml
+++ b/tests/golang-external-secrets-normal.expected.yaml
@@ -5697,7 +5697,7 @@ spec:
           secretName: golang-external-secrets-webhook
 ---
 # Source: golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: vault-backend


### PR DESCRIPTION
This way we align with the v1beta1 externalsecrets we have already
switched to.
