### PR TITLE
Add support for .disabled in imperative jobs

### DIFF
--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -35,6 +35,7 @@ spec:
               - name: git
                 mountPath: "/git"
     {{- range $.Values.clusterGroup.imperative.jobs }}
+      {{- if ne (.disabled | default "false" | toString | lower ) "true" }}
             - name: {{ .name }}
               image: {{ .image | default $.Values.clusterGroup.imperative.image }}
               imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
@@ -60,6 +61,7 @@ spec:
               - name: values-volume
                 mountPath: /values/values.yaml
                 subPath: values.yaml
+      {{- end }}
     {{- end }}
           containers:
           - name: {{ $.Values.clusterGroup.imperative.jobName }}-done


### PR DESCRIPTION
If a job was the "disabled: true" key in its definition
it won't be rendered in the CronJob definition.
The use case here is to be able to simply noop some jobs
without having to remove them fully.

Tested with:
  imperative:
    jobs:
    - name: foo
      playbook: ansible/playbooks/foo.yml

    - name: bar
      playbook: ansible/playbooks/bar.yml
      disabled: true

    - name: baz
      playbook: ansible/playbooks/baz.yml
      disabled: false

The above generates the following initContainers in the
CronJob definition (note how bar is skipped):

initContainers:
...
  - name: foo
    image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
    command:
    ...
      - ansible/playbooks/foo.yml
  - name: baz
    command:
    ...
      - ansible/playbooks/test.yml
