### PR TITLE
WIP stop fetching values files over URL. Use local files from git

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -41,8 +41,8 @@ spec:
                     helm:
                       ignoreMissingValueFiles: true
                       valueFiles:
-                      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
-                      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ .name }}.yaml"
+                      - "{{ default "" .valuesDirectoryURL }}/values-global.yaml"
+                      - "{{ default "" .valuesDirectoryURL }}/values-{{ .name }}.yaml"
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -53,7 +53,7 @@ spec:
                       - name: global.pattern
                         value: {{ $.Values.global.pattern }}
                       - name: global.valuesDirectoryURL
-                        value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
+                        value: {{ default "" .valuesDirectoryURL }}
                       - name: global.hubClusterDomain
                         value: {{ $.Values.global.hubClusterDomain }}
                       - name: global.localClusterDomain

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -26,8 +26,13 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
+      {{- if .chart }}
       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- else }}
+      - "{{ default "" .valuesDirectoryURL }}/values-global.yaml"
+      - "{{ default "" .valuesDirectoryURL }}/values-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- end }}
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -39,7 +44,11 @@ spec:
         - name: global.pattern
           value: {{ $.Values.global.pattern }}
         - name: global.valuesDirectoryURL
+          {{- if .chart }}
           value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
+          {{- else }}
+          value: {{ default "" .valuesDirectoryURL }}
+          {{- end }}
         - name: global.hubClusterDomain
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain

--- a/clustergroup/templates/argocd.yaml
+++ b/clustergroup/templates/argocd.yaml
@@ -20,8 +20,8 @@ spec:
     \ generate:\n    command: [\"kustomize\"]\n    args: [\"build\", \"--enable-helm\"]\n- name:
     helm-with-kustomize\n  init:\n    command: [\"/bin/sh\", \"-c\"]\n    args: [\"helm
     dependency build\"]\n  generate:\n    command: [/bin/bash, -c]\n    args: [\"helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-    -f {{ .Values.global.valuesDirectoryURL }}/values-global.yaml
-    -f {{ .Values.global.valuesDirectoryURL }}/values-{{ .Values.clusterGroup.name }}.yaml
+    -f /values-global.yaml
+    -f /values-{{ .Values.clusterGroup.name }}.yaml
     --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
     --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
     --set global.namespace=$ARGOCD_APP_NAMESPACE

--- a/legacy-install/templates/argocd/application.yaml
+++ b/legacy-install/templates/argocd/application.yaml
@@ -19,8 +19,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-global.yaml"
-      - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-{{ .Values.main.clusterGroupName }}.yaml"
+      - "{{ default "" .Values.main.git.valuesDirectoryURL }}/values-global.yaml"
+      - "{{ default "" .Values.main.git.valuesDirectoryURL }}/values-{{ .Values.main.clusterGroupName }}.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -121,8 +121,8 @@ spec:
                     helm:
                       ignoreMissingValueFiles: true
                       valueFiles:
-                      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-                      - "https://github.com/pattern-clone/mypattern/raw/main/values-edge.yaml"
+                      - "/values-global.yaml"
+                      - "/values-edge.yaml"
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -133,7 +133,7 @@ spec:
                       - name: global.pattern
                         value: mypattern
                       - name: global.valuesDirectoryURL
-                        value: https://github.com/pattern-clone/mypattern/raw/main
+                        value: 
                       - name: global.hubClusterDomain
                         value: hub.example.com
                       - name: global.localClusterDomain

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -78,8 +78,8 @@ spec:
     \ generate:\n    command: [\"kustomize\"]\n    args: [\"build\", \"--enable-helm\"]\n- name:
     helm-with-kustomize\n  init:\n    command: [\"/bin/sh\", \"-c\"]\n    args: [\"helm
     dependency build\"]\n  generate:\n    command: [/bin/bash, -c]\n    args: [\"helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-    -f https://github.com/pattern-clone/common/raw/main/values-global.yaml
-    -f https://github.com/pattern-clone/common/raw/main/values-example.yaml
+    -f /values-global.yaml
+    -f /values-example.yaml
     --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
     --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
     --set global.namespace=$ARGOCD_APP_NAMESPACE

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -456,8 +456,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -469,7 +469,7 @@ spec:
         - name: global.pattern
           value: mypattern
         - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
+          value: 
         - name: global.hubClusterDomain
           value: hub.example.com
         - name: global.localClusterDomain
@@ -507,8 +507,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -520,7 +520,7 @@ spec:
         - name: global.pattern
           value: mypattern
         - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
+          value: 
         - name: global.hubClusterDomain
           value: hub.example.com
         - name: global.localClusterDomain
@@ -551,8 +551,8 @@ spec:
     \ generate:\n    command: [\"kustomize\"]\n    args: [\"build\", \"--enable-helm\"]\n- name:
     helm-with-kustomize\n  init:\n    command: [\"/bin/sh\", \"-c\"]\n    args: [\"helm
     dependency build\"]\n  generate:\n    command: [/bin/bash, -c]\n    args: [\"helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-    -f https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml
-    -f https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml
+    -f /values-global.yaml
+    -f /values-example.yaml
     --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
     --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
     --set global.namespace=$ARGOCD_APP_NAMESPACE

--- a/tests/legacy-install-naked.expected.yaml
+++ b/tests/legacy-install-naked.expected.yaml
@@ -27,8 +27,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-default.yaml"
+      - "/values-global.yaml"
+      - "/values-default.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL

--- a/tests/legacy-install-normal.expected.yaml
+++ b/tests/legacy-install-normal.expected.yaml
@@ -27,8 +27,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL


### PR DESCRIPTION
WIP Stop fetching values files over URL. Use local files from git

Starting with ArgoCD 2.3 (openshift-gitops 1.4.x) [1] we do can use values
files from git directly. This avoids us fetching values files over http
and potentially avoid issue https://issues.redhat.com/browse/GITOPS-2069
"argocd application do not update when values file changed in helm repo"

We do this for all helm applications *except* when an external chart is
used. In such a case argo will unpack the remote chart into its own
folder and in such a case /values-{hub,region-one}.yaml etc. will not be
present. To make sure that we pass our correct values in this external
chart case, we still go back to the old "fetch-over-http" method.

Tested and got an MCG pattern deployed correctly.

[1] https://github.com/argoproj/argo-cd/blob/bb77664b6f0299bb332843bcd2524820c7ba1558/reposerver/repository/repository.go#L674