### PR TITLE
In push_secrets wait more if the vault is unsealed

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -2,10 +2,19 @@
 - include_tasks: pre_check.yaml
 - include_tasks: vault_status.yaml
 
-- name: Fail if the vault is sealed
-  ansible.builtin.fail:
-    msg: "The vault is still sealed, cannot continue"
-  failed_when: vault_status['sealed'] | bool
+# Unfortunately we cannot loop vault_status and just check if the vault is unsealed
+# https://github.com/ansible/proposals/issues/136
+# So here we keep running the 'vault status' command until sealed is set to false
+- name: If the vault is still sealed we need to retry
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: vault status -format=json
+  register: vault_status_json
+  until: "'stdout' in vault_status_json and (not (vault_status_json.stdout | from_json)['sealed'] | bool)"
+  retries: 20
+  delay: 45
+  failed_when: "'stdout_lines' not in vault_status_json"
 
 - name: Check for existence of "{{ values_secret }}"
   ansible.builtin.stat:


### PR DESCRIPTION
If a user chooses to unseal the vault from inside the cluster
(i.e. without make vault-init) make load-secrets will probably
fail because the cronjob to unseal the vault will not have
run by the time we try to inject the secrets into the vault.

Since ansible has no mechanism to retry/until over an include_task,
we just add a vault_status exec call that loops a few times until
sealed turns false.

Tested this with unsealing done from within the cluster via a cronjob
and via make vault-init.
