### PR TITLE
Add job to unseal the vault from the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spe
 
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" --set clusterGroup.unsealVaultInsideCluster=true
+TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" --set clusterGroup.insecureUnsealVaultInsideCluster=true
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spe
 
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml"
+TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" --set clusterGroup.unsealVaultInsideCluster=true
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
 

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -130,6 +130,23 @@
     msg: "{{ vault_cmds }}"
   when: debug | default(False) | bool
 
+# This step is not really needed when running make vault-init + load-secrets as
+# everything is sequential
+# It is needed when the vault is unsealed/configured inside the cluster and load-secrets
+# gets run *while* the cronjob configures the vault. I.e. it might be half configured and return
+# errors
+- name: Make sure that the vault auth policy exists
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command:
+      sh -c "vault list auth/{{ vault_hub }}/role | grep '{{ vault_hub }}-role'"
+  register: vault_role_cmd
+  until: vault_role_cmd.rc == 0
+  retries: 20
+  delay: 45
+  changed_when: false
+
 - name: Add the actual secrets to the vault
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"

--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/* git-init InitContainer */}}
+{{- define "imperative.initcontainers.gitinit" }}
+- name: git-init
+  image: {{ $.Values.clusterGroup.imperative.image }}
+  imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+  env:
+    - name: HOME
+      value: /git/home
+  command:
+  - 'sh'
+  - '-c'
+  - "mkdir /git/{repo,home};git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- {{ $.Values.global.repoURL }} /git/repo;chmod 0770 /git/{repo,home}"
+  volumeMounts:
+  - name: git
+    mountPath: "/git"
+{{- end }}
+
+{{/* volume-mounts for all containers */}}
+{{- define "imperative.volumemounts" }}
+- name: git
+  mountPath: "/git"
+- name: values-volume
+  mountPath: /values/values.yaml
+  subPath: values.yaml
+{{- end }}

--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -17,15 +17,15 @@
 
 {{/* Final done container */}}
 {{- define "imperative.containers.done" }}
-- name: done
+- name: "done"
   image: {{ $.Values.clusterGroup.imperative.image }}
   imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
   command:
-  - 'sh'
-  - '-c'
-  - echo
-  - 'done'
-  - '\n'
+    - 'sh'
+    - '-c'
+    - 'echo'
+    - 'done'
+    - '\n'
 {{- end }}
 
 {{/* volume-mounts for all containers */}}

--- a/clustergroup/templates/imperative/_helpers.tpl
+++ b/clustergroup/templates/imperative/_helpers.tpl
@@ -15,6 +15,19 @@
     mountPath: "/git"
 {{- end }}
 
+{{/* Final done container */}}
+{{- define "imperative.containers.done" }}
+- name: done
+  image: {{ $.Values.clusterGroup.imperative.image }}
+  imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+  command:
+  - 'sh'
+  - '-c'
+  - echo
+  - 'done'
+  - '\n'
+{{- end }}
+
 {{/* volume-mounts for all containers */}}
 {{- define "imperative.volumemounts" }}
 - name: git

--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -21,7 +21,7 @@ spec:
           initContainers:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there
-            {{- include  "imperative.initcontainers.gitinit" . | indent 12 -}}
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 }}
     {{- range $.Values.clusterGroup.imperative.jobs }}
       {{- if ne (.disabled | default "false" | toString | lower ) "true" }}
             - name: {{ .name }}
@@ -52,21 +52,11 @@ spec:
                 {{- end }}
                 - {{ .playbook }}
               volumeMounts:
-                {{- include "imperative.volumemounts" . | indent 16 -}}
+                {{- include "imperative.volumemounts" . | indent 16 }}
       {{- end }}
     {{- end }}
           containers:
-          - name: {{ $.Values.clusterGroup.imperative.jobName }}-done
-            image: {{ $.Values.clusterGroup.imperative.image }}
-            imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
-            command:
-            - 'sh'
-            - '-c'
-            - echo
-            - {{ range $.Values.clusterGroup.imperative.jobs }}{{ .name }}{{ end }}
-            - '\n'
-            volumeMounts:
-              {{- include "imperative.volumemounts" . | indent 14 }}
+          {{- include "imperative.containers.done" . | indent 12 }}
           volumes:
           - name: git
             emptyDir: {}

--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -21,19 +21,7 @@ spec:
           initContainers:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there
-            - name: git-init
-              image: {{ $.Values.clusterGroup.imperative.image }}
-              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
-              env:
-                - name: HOME
-                  value: /git/home
-              command:
-              - 'sh'
-              - '-c'
-              - "mkdir /git/{repo,home};git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- {{ $.Values.global.repoURL }} /git/repo;chmod 0770 /git/{repo,home}"
-              volumeMounts:
-              - name: git
-                mountPath: "/git"
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 -}}
     {{- range $.Values.clusterGroup.imperative.jobs }}
       {{- if ne (.disabled | default "false" | toString | lower ) "true" }}
             - name: {{ .name }}
@@ -64,11 +52,7 @@ spec:
                 {{- end }}
                 - {{ .playbook }}
               volumeMounts:
-              - name: git
-                mountPath: "/git"
-              - name: values-volume
-                mountPath: /values/values.yaml
-                subPath: values.yaml
+                {{- include "imperative.volumemounts" . | indent 16 -}}
       {{- end }}
     {{- end }}
           containers:
@@ -82,11 +66,7 @@ spec:
             - {{ range $.Values.clusterGroup.imperative.jobs }}{{ .name }}{{ end }}
             - '\n'
             volumeMounts:
-            - name: git
-              mountPath: "/git"
-            - name: values-volume
-              mountPath: /values/values.yaml
-              subPath: values.yaml
+              {{- include "imperative.volumemounts" . | indent 14 }}
           volumes:
           - name: git
             emptyDir: {}

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -1,5 +1,5 @@
-{{/* Only define this if the values.unsealVaultInsideCluster is set to tre and we're on the cluster */}}
-{{- if and $.Values.clusterGroup.unsealVaultInsideCluster $.Values.clusterGroup.isHubCluster }}
+{{/* Only define this if the values.insecureUnsealVaultInsideCluster is set to tre and we're on the cluster */}}
+{{- if and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -7,7 +7,7 @@ metadata:
   name: unsealvault-cronjob
   namespace: {{ $.Values.clusterGroup.imperative.namespace}}
 spec:
-  schedule: {{ $.Values.clusterGroup.imperative.unsealVaultInsideClusterSchedule | quote }}
+  schedule: {{ $.Values.clusterGroup.imperative.insecureUnsealVaultInsideClusterSchedule | quote }}
   # if previous Job is still running, skip execution of a new Job
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -21,7 +21,7 @@ spec:
           initContainers:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there
-            {{- include  "imperative.initcontainers.gitinit" . | indent 12 -}}
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 }}
             - name: unseal-playbook
               image: {{ $.Values.clusterGroup.imperative.image }}
               imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
@@ -46,19 +46,9 @@ spec:
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:
-                {{- include "imperative.volumemounts" . | indent 16 -}}
+                {{- include "imperative.volumemounts" . | indent 16 }}
           containers:
-          - name: unsealvault-job-done
-            image: {{ $.Values.clusterGroup.imperative.image }}
-            imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
-            command:
-            - 'sh'
-            - '-c'
-            - echo
-            - 'Unseal job'
-            - '\n'
-            volumeMounts:
-                {{- include "imperative.volumemounts" . | indent 14 -}}
+          {{- include "imperative.containers.done" . | indent 12 }}
           volumes:
           - name: git
             emptyDir: {}

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -1,0 +1,89 @@
+{{/* Only define this if the values.unsealVaultInsideCluster is set to tre and we're on the cluster */}}
+{{- if and $.Values.clusterGroup.unsealVaultInsideCluster $.Values.clusterGroup.isHubCluster }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: unsealvault-cronjob
+  namespace: {{ $.Values.clusterGroup.imperative.namespace}}
+spec:
+  schedule: {{ $.Values.clusterGroup.imperative.unsealVaultInsideClusterSchedule | quote }}
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ $.Values.clusterGroup.imperative.activeDeadlineSeconds }}
+      template:
+        metadata:
+          name: unsealvault-job
+        spec:
+          serviceAccountName: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there
+            - name: git-init
+              image: {{ $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- {{ $.Values.global.repoURL }} /git/repo;chmod 0770 /git/{repo,home}"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+            - name: unseal-playbook
+              image: {{ $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - {{ .timeout | default "600" | quote }}
+                - ansible-playbook
+                {{- if $.Values.clusterGroup.imperative.verbosity }}
+                - {{ $.Values.clusterGroup.imperative.verbosity }}
+                {{- end }}
+                - -e
+                - "@/values/values.yaml"
+                - -e
+                - '{"file_unseal": false}'
+                - -t
+                - 'vault_init,vault_unseal,vault_secrets_init'
+                - "common/ansible/playbooks/vault/vault.yaml"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+              - name: values-volume
+                mountPath: /values/values.yaml
+                subPath: values.yaml
+          containers:
+          - name: unsealvault-job-done
+            image: {{ $.Values.clusterGroup.imperative.image }}
+            imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+            command:
+            - 'sh'
+            - '-c'
+            - echo
+            - 'Unseal job'
+            - '\n'
+            volumeMounts:
+            - name: git
+              mountPath: "/git"
+            - name: values-volume
+              mountPath: /values/values.yaml
+              subPath: values.yaml
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}
+          restartPolicy: Never
+{{ end }}

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -21,19 +21,7 @@ spec:
           initContainers:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there
-            - name: git-init
-              image: {{ $.Values.clusterGroup.imperative.image }}
-              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
-              env:
-                - name: HOME
-                  value: /git/home
-              command:
-              - 'sh'
-              - '-c'
-              - "mkdir /git/{repo,home};git clone --single-branch --branch {{ $.Values.global.targetRevision }} --depth 1 -- {{ $.Values.global.repoURL }} /git/repo;chmod 0770 /git/{repo,home}"
-              volumeMounts:
-              - name: git
-                mountPath: "/git"
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 -}}
             - name: unseal-playbook
               image: {{ $.Values.clusterGroup.imperative.image }}
               imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
@@ -58,11 +46,7 @@ spec:
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:
-              - name: git
-                mountPath: "/git"
-              - name: values-volume
-                mountPath: /values/values.yaml
-                subPath: values.yaml
+                {{- include "imperative.volumemounts" . | indent 16 -}}
           containers:
           - name: unsealvault-job-done
             image: {{ $.Values.clusterGroup.imperative.image }}
@@ -74,11 +58,7 @@ spec:
             - 'Unseal job'
             - '\n'
             volumeMounts:
-            - name: git
-              mountPath: "/git"
-            - name: values-volume
-              mountPath: /values/values.yaml
-              subPath: values.yaml
+                {{- include "imperative.volumemounts" . | indent 14 -}}
           volumes:
           - name: git
             emptyDir: {}

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -10,6 +10,9 @@ global:
 clusterGroup:
   name: example
   isHubCluster: true
+  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
+  # is fundamentally insecure
+  unsealVaultInsideCluster: false
 
   imperative:
     jobs: []
@@ -25,6 +28,10 @@ clusterGroup:
     activeDeadlineSeconds: 3600
     # By default we run this every 10minutes
     schedule: "*/10 * * * *"
+    # Schedule used to trigger the vault unsealing (if explicitely enabled)
+    # Set to run every 9 minutes in order for load-secrets to succeed within
+    # a reasonable amount of time (it waits up to 15 mins)
+    unsealVaultInsideClusterSchedule: "*/9 * * * *"
     # Increase ansible verbosity with '-v' or '-vv..'
     verbosity: ""
     serviceAccountCreate: true

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -12,7 +12,7 @@ clusterGroup:
   isHubCluster: true
   # Note: setting this to true stores the vault unseal keys inside a cluster secret and
   # is fundamentally insecure
-  unsealVaultInsideCluster: false
+  insecureUnsealVaultInsideCluster: false
 
   imperative:
     jobs: []
@@ -31,7 +31,7 @@ clusterGroup:
     # Schedule used to trigger the vault unsealing (if explicitely enabled)
     # Set to run every 9 minutes in order for load-secrets to succeed within
     # a reasonable amount of time (it waits up to 15 mins)
-    unsealVaultInsideClusterSchedule: "*/9 * * * *"
+    insecureUnsealVaultInsideClusterSchedule: "*/9 * * * *"
     # Increase ansible verbosity with '-v' or '-vv..'
     verbosity: ""
     serviceAccountCreate: true
@@ -71,7 +71,7 @@ clusterGroup:
 #
 #  projects:
 #  - datacenter
-# 
+#
 #  applications:
 #  - name: acm
 #    namespace: default

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -126,7 +126,7 @@ data:
         pipelines:
           csv: redhat-openshift-pipelines.v1.5.2
           name: openshift-pipelines-operator-rh
-      unsealVaultInsideCluster: false
+      unsealVaultInsideCluster: true
     global:
       git:
         account: hybrid-cloud-patterns
@@ -280,7 +280,7 @@ spec:
           serviceAccountName: imperative-sa
           initContainers:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
-            # reason for that is ansible refuses to create temporary folders in there
+            # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
               image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
               imagePullPolicy: Always
@@ -310,28 +310,100 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - ansible/test.yml
+              volumeMounts:                
+                - name: git
+                  mountPath: "/git"
+                - name: values-volume
+                  mountPath: /values/values.yaml
+                  subPath: values.yaml
+          containers:            
+            - name: "done"
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              command:
+                - 'sh'
+                - '-c'
+                - 'echo'
+                - 'done'
+                - '\n'
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: helm-values-configmap
+          restartPolicy: Never
+---
+# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: unsealvault-cronjob
+  namespace: imperative
+spec:
+  schedule: "*/9 * * * *"
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: unsealvault-job
+        spec:
+          serviceAccountName: imperative-sa
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there            
+            - name: git-init
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch  --depth 1 -- https://github.com/pattern-clone/mypattern /git/repo;chmod 0770 /git/{repo,home}"
               volumeMounts:
               - name: git
                 mountPath: "/git"
-              - name: values-volume
-                mountPath: /values/values.yaml
-                subPath: values.yaml
-          containers:
-          - name: imperative-job-done
-            image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
-            imagePullPolicy: Always
-            command:
-            - 'sh'
-            - '-c'
-            - echo
-            - test
-            - '\n'
-            volumeMounts:
-            - name: git
-              mountPath: "/git"
-            - name: values-volume
-              mountPath: /values/values.yaml
-              subPath: values.yaml
+            - name: unseal-playbook
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - "600"
+                - ansible-playbook
+                - -e
+                - "@/values/values.yaml"
+                - -e
+                - '{"file_unseal": false}'
+                - -t
+                - 'vault_init,vault_unseal,vault_secrets_init'
+                - "common/ansible/playbooks/vault/vault.yaml"
+              volumeMounts:                
+                - name: git
+                  mountPath: "/git"
+                - name: values-volume
+                  mountPath: /values/values.yaml
+                  subPath: values.yaml
+          containers:            
+            - name: "done"
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              command:
+                - 'sh'
+                - '-c'
+                - 'echo'
+                - 'done'
+                - '\n'
           volumes:
           - name: git
             emptyDir: {}

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -90,6 +90,7 @@ data:
         schedule: '*/10 * * * *'
         serviceAccountCreate: true
         serviceAccountName: imperative-sa
+        unsealVaultInsideClusterSchedule: '*/9 * * * *'
         valuesConfigMap: helm-values-configmap
         verbosity: ""
       isHubCluster: true
@@ -125,6 +126,7 @@ data:
         pipelines:
           csv: redhat-openshift-pipelines.v1.5.2
           name: openshift-pipelines-operator-rh
+      unsealVaultInsideCluster: false
     global:
       git:
         account: hybrid-cloud-patterns

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -80,6 +80,7 @@ data:
         cronJobName: imperative-cronjob
         image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
         imagePullPolicy: Always
+        insecureUnsealVaultInsideClusterSchedule: '*/9 * * * *'
         jobName: imperative-job
         jobs:
         - name: test
@@ -90,9 +91,9 @@ data:
         schedule: '*/10 * * * *'
         serviceAccountCreate: true
         serviceAccountName: imperative-sa
-        unsealVaultInsideClusterSchedule: '*/9 * * * *'
         valuesConfigMap: helm-values-configmap
         verbosity: ""
+      insecureUnsealVaultInsideCluster: true
       isHubCluster: true
       managedClusterGroups:
       - clusterSelector:
@@ -126,7 +127,6 @@ data:
         pipelines:
           csv: redhat-openshift-pipelines.v1.5.2
           name: openshift-pipelines-operator-rh
-      unsealVaultInsideCluster: true
     global:
       git:
         account: hybrid-cloud-patterns


### PR DESCRIPTION
This commit adds support for a separate unsealJob CronJob template which is
enabled when when a user sets clusterGroup.unsealVaultInsideCluster to
true and the template is applied to the hub. This makes it so that the
cluster is unsealed directly via cronjob and the vault unseal keys are
stored inside a secret in OCP. Note that this is provided for
convenience only and it is not recommended to store vault's unseal keys
and root login token inside a kubernetes cluster.

Two different design choices were explored and tried:
A) Via some global switch + an additional unseal template (which is what
this review is all about)
If "clusterGroup.unsealVaultInsideCluster" is true we render an additional template
in common/clustergroup/templates/imperative/unsealjob.yaml which then kicks off
the playbook that unseals the vault and stores the unseal keys inside some secret in
ocp (imperative/vaultkeys by default)

B) Via a defined job (disabled by default) like the following inside
values-hub.yaml:
    - name: vault-unseal
      playbook: common/ansible/playbooks/vault/vault.yaml
      tags: "vault_init,vault_unseal,vault_secrets_init"
      extravars:
        - '{"file_unseal": false}'
      disabled: true

In both cases, we need to make sure that 'make vault-init' does not get
run whenever the "unseal the vault inside the cluster" is enabled.
Otherwise we get two things doing the unsealing in parallel and the
second one (which will almost always be the cronjob) will fail forever.

While choice (B) offered some advantages (less duplication, more
explicit), it made the "detect if unsealVaultInsideCluster inside the
Makefile" rather hard and quite error prone.
Mainly for this reason I ended up with with (A).

Tested with clusterGroup.unsealVaultInsideCluster both set to true and
to false and got a correctly configured and set vault in both.
