### PR TITLE
Add ignoreMissingValueFiles: true on helm charts

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -39,6 +39,7 @@ spec:
                     targetRevision: {{ coalesce .targetRevision $.Values.global.targetRevision }}
                     path: {{ default "common/clustergroup" .path }}
                     helm:
+                      ignoreMissingValueFiles: true
                       valueFiles:
                       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
                       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ .name }}.yaml"

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -22,6 +22,7 @@ spec:
     plugin: {{ .plugin | toPrettyJson }}
     {{- else if not .kustomize }}
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
       - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ $.Values.clusterGroup.name }}.yaml"

--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -15,6 +15,7 @@ spec:
     targetRevision: {{ .Values.main.git.revision }}
     path: common/clustergroup
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-global.yaml"
       - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-{{ .Values.main.clusterGroupName }}.yaml"

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -119,6 +119,7 @@ spec:
                     targetRevision: main
                     path: common/clustergroup
                     helm:
+                      ignoreMissingValueFiles: true
                       valueFiles:
                       - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
                       - "https://github.com/pattern-clone/mypattern/raw/main/values-edge.yaml"

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -378,6 +378,7 @@ spec:
     targetRevision: 
     path: common/acm
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
       - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
@@ -426,6 +427,7 @@ spec:
     targetRevision: 
     path: charts/datacenter/pipelines
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
       - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"

--- a/tests/install-naked.expected.yaml
+++ b/tests/install-naked.expected.yaml
@@ -23,6 +23,7 @@ spec:
     targetRevision: main
     path: common/clustergroup
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
       - "https://github.com/pattern-clone/mypattern/raw/main/values-default.yaml"

--- a/tests/install-normal.expected.yaml
+++ b/tests/install-normal.expected.yaml
@@ -23,6 +23,7 @@ spec:
     targetRevision: main
     path: common/clustergroup
     helm:
+      ignoreMissingValueFiles: true
       valueFiles:
       - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
       - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"


### PR DESCRIPTION
This will allow us to always add values files that do not exist,
like per-cluster overrides and so on.

Tested on a multicloud-gitops deployment successfully
