### PR TITLE
Add finalizers to all applications

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -31,7 +31,7 @@ spec:
                   name: {{ $.Values.global.pattern }}-{{ .name }}
                   namespace: openshift-gitops
                   finalizers:
-                  - argoproj.io/finalizer
+                  - resources-finalizer.argocd.argoproj.io/foreground
                 spec:
                   project: default
                   source:

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -5,6 +5,8 @@ kind: Application
 metadata:
   name: {{ .name }}
   namespace: {{ $namespace }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster

--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -5,6 +5,8 @@ kind: Application
 metadata:
   name: {{ .Release.Name }}-{{ .Values.main.clusterGroupName }}
   namespace: openshift-gitops
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -111,7 +111,7 @@ spec:
                   name: mypattern-edge
                   namespace: openshift-gitops
                   finalizers:
-                  - argoproj.io/finalizer
+                  - resources-finalizer.argocd.argoproj.io/foreground
                 spec:
                   project: default
                   source:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -368,6 +368,8 @@ kind: Application
 metadata:
   name: acm
   namespace: mypattern-example
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster
@@ -417,6 +419,8 @@ kind: Application
 metadata:
   name: pipelines
   namespace: mypattern-example
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster

--- a/tests/install-naked.expected.yaml
+++ b/tests/install-naked.expected.yaml
@@ -13,6 +13,8 @@ kind: Application
 metadata:
   name: install-default
   namespace: openshift-gitops
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster

--- a/tests/install-normal.expected.yaml
+++ b/tests/install-normal.expected.yaml
@@ -13,6 +13,8 @@ kind: Application
 metadata:
   name: install-example
   namespace: openshift-gitops
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
     name: in-cluster


### PR DESCRIPTION
As suggested by @beekhof via
https://github.com/hybrid-cloud-patterns/industrial-edge/pull/123/ we
add foreground finalizers for all of our argo applications. While we're
at it we replace acm's application policy finalizer from
"argoproj.io/finalizer" to the same foreground one we use in the other
applications: "resources-finalizer.argocd.argoproj.io/foreground"

This should improve our uninstall story in general.
