### PR TITLE
Move to import_tasks for vault_init/main.yml

### DIFF
--- a/ansible/roles/vault_utils/tasks/main.yml
+++ b/ansible/roles/vault_utils/tasks/main.yml
@@ -1,35 +1,20 @@
 ---
 - name: Delete vault
-  include_tasks:
-    file: vault_delete.yaml
-    apply:
-      tags: [never, vault_delete]
-  tags: [never, vault_delete]
+  import_tasks: vault_delete.yaml
+  tags: vault_delete
 
 - name: Run vault init tasks
-  include_tasks:
-    file: vault_init.yaml
-    apply:
-      tags: [never, vault_init]
-  tags: [never, vault_init]
+  import_tasks: vault_init.yaml
+  tags: vault_init
 
 - name: Unseal vault
-  include_tasks:
-    file: vault_unseal.yaml
-    apply:
-      tags: [never, vault_unseal]
-  tags: [never, vault_unseal]
+  import_tasks: vault_unseal.yaml
+  tags: vault_unseal
 
 - name: Vault secrets init
-  include_tasks:
-    file: vault_secrets_init.yaml
-    apply:
-      tags: [never, vault_secrets_init]
-  tags: [never, vault_secrets_init]
+  import_tasks: vault_secrets_init.yaml
+  tags: vault_secrets_init
 
 - name: Load secrets
-  include_tasks:
-    file: push_secrets.yaml
-    apply:
-      tags: [never, push_secrets]
-  tags: [never, push_secrets]
+  import_tasks: push_secrets.yaml
+  tags: push_secrets


### PR DESCRIPTION
The problem with the current approach, which is working just fine, is
the following:
- When from a pattern role like 'bootstrap' we import_role value_utils and
  pass the needed tags, those are completely ignored.

Let's switch to import_tasks, which is more efficient as it is more
static and it allows us to make things work correctly.

Tested with a full MCG deploy. Also verified that 'make load-secrets'
works separately and only loads secret (i.e. tags keep on working).
Also checked that './common/scripts/vault-utils.sh vault_delete'
works correctly

Also tested by running 'ansible-playbook ansible/site.yml' in MCG and
observed that now the vault tasks are correctly run.
