### PR TITLE
Drop valuesDirectoryURL entirely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spe
 
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) --set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/mypattern/raw/main" --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" --set clusterGroup.insecureUnsealVaultInsideCluster=true
+TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.pattern="mypattern" --set global.namespace="pattern-namespace" --set global.hubClusterDomain=hub.example.com --set global.localClusterDomain=region.example.com --set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" --set clusterGroup.insecureUnsealVaultInsideCluster=true
 PATTERN_OPTS=-f common/examples/values-example.yaml
 
 

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -41,8 +41,8 @@ spec:
                     helm:
                       ignoreMissingValueFiles: true
                       valueFiles:
-                      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
-                      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ .name }}.yaml"
+                      - "/values-global.yaml"
+                      - "/values-{{ .name }}.yaml"
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -52,8 +52,6 @@ spec:
                         value: $ARGOCD_APP_NAMESPACE
                       - name: global.pattern
                         value: {{ $.Values.global.pattern }}
-                      - name: global.valuesDirectoryURL
-                        value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
                       - name: global.hubClusterDomain
                         value: {{ $.Values.global.hubClusterDomain }}
                       - name: global.localClusterDomain

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -1,6 +1,5 @@
 global:
   pattern: none
-  valuesDirectoryURL: none
   repoURL: none
   targetRevision: main
 

--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -26,8 +26,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-global.yaml"
-      - "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}/values-{{ $.Values.clusterGroup.name }}.yaml"
+      - "/values-global.yaml"
+      - "/values-{{ $.Values.clusterGroup.name }}.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -38,8 +38,6 @@ spec:
           value: $ARGOCD_APP_NAMESPACE
         - name: global.pattern
           value: {{ $.Values.global.pattern }}
-        - name: global.valuesDirectoryURL
-          value: {{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}
         - name: global.hubClusterDomain
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain

--- a/clustergroup/templates/argocd.yaml
+++ b/clustergroup/templates/argocd.yaml
@@ -31,15 +31,14 @@ spec:
       generate:
         command: ["/bin/bash", "-c"]
         args: ["helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-            -f {{ .Values.global.valuesDirectoryURL }}/values-global.yaml
-            -f {{ .Values.global.valuesDirectoryURL }}/values-{{ .Values.clusterGroup.name }}.yaml
+            -f $(git rev-parse --show-toplevel)/values-global.yaml
+            -f $(git rev-parse --show-toplevel)/values-{{ .Values.clusterGroup.name }}.yaml
             --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
             --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
             --set global.namespace=$ARGOCD_APP_NAMESPACE
             --set global.pattern={{ .Values.global.pattern }}
             --set global.hubClusterDomain={{ .Values.global.hubClusterDomain }}
             --set global.localClusterDomain={{ coalesce .Values.global.localClusterDomain .Values.global.hubClusterDomain }}
-            --set global.valuesDirectoryURL={{ .Values.global.valuesDirectoryURL }}
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -1,6 +1,5 @@
 global:
   pattern: common
-  valuesDirectoryURL: https://github.com/pattern-clone/common/raw/main
   options:
     useCSV: True
     syncPolicy: Automatic
@@ -46,7 +45,6 @@ clusterGroup:
 #  - name: factory
 #    # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git
 #    # Location of values-global.yaml, values-{name}.yaml, values-{app}.yaml
-#    # valuesDirectoryURL: https://github.com/dagger-refuse-cool/edge-gitops/raw/main/
 #    targetRevision: main
 #    path: applications/factory
 #    helmOverrides:

--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -1,5 +1,3 @@
-{{- $valuesDirectoryURL :=  cat .Values.main.git.repoURL "/raw/" .Values.main.git.revision -}}
-{{- $valuesDirectoryURLFixed :=  $valuesDirectoryURL | replace " " "" | replace ".git" "" }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -19,8 +17,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-global.yaml"
-      - "{{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}/values-{{ .Values.main.clusterGroupName }}.yaml"
+      - "/values-global.yaml"
+      - "/values-{{ .Values.main.clusterGroupName }}.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL
@@ -29,8 +27,6 @@ spec:
           value: $ARGOCD_APP_SOURCE_TARGET_REVISION
         - name: global.namespace
           value: $ARGOCD_APP_NAMESPACE
-        - name: global.valuesDirectoryURL
-          value: {{ coalesce .Values.main.git.valuesDirectoryURL $valuesDirectoryURLFixed }}
         - name: global.pattern
           value: {{ .Release.Name }}
         - name: global.hubClusterDomain

--- a/install/values.yaml
+++ b/install/values.yaml
@@ -2,7 +2,6 @@ main:
   git:
     repoURL: https://github.com/pattern-clone/mypattern
     revision: main
-    #valuesDirectoryURL: https://github.com/hybrid-cloud-patterns/industrial-edge/raw/main/
 
   options:
     syncPolicy: Automatic

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -121,8 +121,8 @@ spec:
                     helm:
                       ignoreMissingValueFiles: true
                       valueFiles:
-                      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-                      - "https://github.com/pattern-clone/mypattern/raw/main/values-edge.yaml"
+                      - "/values-global.yaml"
+                      - "/values-edge.yaml"
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -132,8 +132,6 @@ spec:
                         value: $ARGOCD_APP_NAMESPACE
                       - name: global.pattern
                         value: mypattern
-                      - name: global.valuesDirectoryURL
-                        value: https://github.com/pattern-clone/mypattern/raw/main
                       - name: global.hubClusterDomain
                         value: hub.example.com
                       - name: global.localClusterDomain

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -89,15 +89,14 @@ spec:
       generate:
         command: ["/bin/bash", "-c"]
         args: ["helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-            -f https://github.com/pattern-clone/common/raw/main/values-global.yaml
-            -f https://github.com/pattern-clone/common/raw/main/values-example.yaml
+            -f $(git rev-parse --show-toplevel)/values-global.yaml
+            -f $(git rev-parse --show-toplevel)/values-example.yaml
             --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
             --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
             --set global.namespace=$ARGOCD_APP_NAMESPACE
             --set global.pattern=common
             --set global.hubClusterDomain=
             --set global.localClusterDomain=
-            --set global.valuesDirectoryURL=https://github.com/pattern-clone/common/raw/main
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -142,7 +142,6 @@ data:
         useCSV: false
       pattern: mypattern
       repoURL: https://github.com/pattern-clone/mypattern
-      valuesDirectoryURL: https://github.com/pattern-clone/mypattern/raw/main
     main:
       clusterGroupName: example
       git:
@@ -456,8 +455,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -468,8 +467,6 @@ spec:
           value: $ARGOCD_APP_NAMESPACE
         - name: global.pattern
           value: mypattern
-        - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
         - name: global.hubClusterDomain
           value: hub.example.com
         - name: global.localClusterDomain
@@ -507,8 +504,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -519,8 +516,6 @@ spec:
           value: $ARGOCD_APP_NAMESPACE
         - name: global.pattern
           value: mypattern
-        - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
         - name: global.hubClusterDomain
           value: hub.example.com
         - name: global.localClusterDomain
@@ -562,15 +557,14 @@ spec:
       generate:
         command: ["/bin/bash", "-c"]
         args: ["helm template . --name-template ${ARGOCD_APP_NAME:0:52}
-            -f https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml
-            -f https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml
+            -f $(git rev-parse --show-toplevel)/values-global.yaml
+            -f $(git rev-parse --show-toplevel)/values-example.yaml
             --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
             --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
             --set global.namespace=$ARGOCD_APP_NAMESPACE
             --set global.pattern=mypattern
             --set global.hubClusterDomain=hub.example.com
             --set global.localClusterDomain=region.example.com
-            --set global.valuesDirectoryURL=https://github.com/pattern-clone/mypattern/raw/main
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/tests/install-naked.expected.yaml
+++ b/tests/install-naked.expected.yaml
@@ -27,8 +27,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-default.yaml"
+      - "/values-global.yaml"
+      - "/values-default.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL
@@ -37,8 +37,6 @@ spec:
           value: $ARGOCD_APP_SOURCE_TARGET_REVISION
         - name: global.namespace
           value: $ARGOCD_APP_NAMESPACE
-        - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
         - name: global.pattern
           value: install
         - name: global.hubClusterDomain

--- a/tests/install-normal.expected.yaml
+++ b/tests/install-normal.expected.yaml
@@ -27,8 +27,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-global.yaml"
-      - "https://github.com/pattern-clone/mypattern/raw/main/values-example.yaml"
+      - "/values-global.yaml"
+      - "/values-example.yaml"
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL
@@ -37,8 +37,6 @@ spec:
           value: $ARGOCD_APP_SOURCE_TARGET_REVISION
         - name: global.namespace
           value: $ARGOCD_APP_NAMESPACE
-        - name: global.valuesDirectoryURL
-          value: https://github.com/pattern-clone/mypattern/raw/main
         - name: global.pattern
           value: install
         - name: global.hubClusterDomain


### PR DESCRIPTION
valuesDirectoryURL was only needed when argo did not support referencing
the values files inside the pattern's git repo root [1]. I.e. any value
file that starts with '/' is assumed to reference the git repo's root.

The main reason we do this, is because argo tends to cache values files
over http and ignore refresh requests (needs a hard-refresh), so the
expectation of doing gitops and values files over http breaks down
somewhat. [2]

We have three possible options to fix this:
1. We ignore the issue [2] entirely. We keep things as is and we revert
   the operator change [3]. I.e. we always fetch the values files from
   URL (this keeps things as is and we unbreak IE when deployed via the
   operator), but we are more susceptible to the gitops values caching
   issue. We could reevaluate this once
   https://github.com/argoproj/argo-cd/pull/8322/files gets implemented
   (potentially at least).

2. We completely drop valuesDirectoryURL and we always reference local files.
   External charts need to override all the things. This is quite simple, but
   has a bit of an unknown as we do not know how painful this could be with
   certain external charts, especially because overrides won't allow for the
   use of variables. This is what we implement with this commit here.

3. We add a bunch of ifs everywhere and use local files when: A) we're not an
   external chart and B) when valuesDirectoryURL is not defined

[1] https://github.com/argoproj/argo-cd/blob/bb77664b6f0299bb332843bcd2524820c7ba1558/reposerver/repository/repository.go#L674
[2] https://issues.redhat.com/browse/GITOPS-2069
[3] https://github.com/hybrid-cloud-patterns/patterns-operator/commit/ba3c35a15dd5f239c7a7d337747b01d494278429
