### PR TITLE
Move operator installation in patterns-operator-system namespace

### DIFF
--- a/operator-install/templates/namespace.yaml
+++ b/operator-install/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.vpoperator.namespace }}

--- a/operator-install/templates/operator_group.yaml
+++ b/operator-install/templates/operator_group.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: patterns-operator
+  namespace: {{ .Values.vpoperator.namespace }}
+spec:

--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -2,7 +2,7 @@ apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: {{ .Release.Name }}
-  namespace: openshift-operators
+  namespace: {{ .Values.vpoperator.namespace }}
 spec:
   clusterGroupName: {{ .Values.main.clusterGroupName }}
   gitSpec:

--- a/operator-install/templates/subscription.yaml
+++ b/operator-install/templates/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: openshift-operators
+  namespace: {{ .Values.vpoperator.namespace }}
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -1,3 +1,6 @@
+vpoperator:
+  namespace: patterns-operator-system
+
 main:
   git:
     repoURL: https://github.com/pattern-clone/mypattern

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -1,10 +1,24 @@
 ---
+# Source: pattern-install/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: patterns-operator-system
+---
+# Source: pattern-install/templates/operator_group.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: patterns-operator
+  namespace: patterns-operator-system
+spec:
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: operator-install
-  namespace: openshift-operators
+  namespace: patterns-operator-system
 spec:
   clusterGroupName: default
   gitSpec:
@@ -16,7 +30,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: openshift-operators
+  namespace: patterns-operator-system
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -1,10 +1,24 @@
 ---
+# Source: pattern-install/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: patterns-operator-system
+---
+# Source: pattern-install/templates/operator_group.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: patterns-operator
+  namespace: patterns-operator-system
+spec:
+---
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: operator-install
-  namespace: openshift-operators
+  namespace: patterns-operator-system
 spec:
   clusterGroupName: example
   gitSpec:
@@ -16,7 +30,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: openshift-operators
+  namespace: patterns-operator-system
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:


### PR DESCRIPTION
The UI installs it by default in the patterns-operator-system namespace.
Let's have UI and make operator-install in sync on this.
