### PR TITLE
Adding support for .spec.config.env to subscription.yaml template

### DIFF
--- a/clustergroup/templates/subscriptions.yaml
+++ b/clustergroup/templates/subscriptions.yaml
@@ -15,6 +15,16 @@ spec:
   sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
   channel: {{ default "stable" $subs.channel }}
   installPlanApproval: {{ coalesce $installPlanValue $.Values.global.options.installPlanApproval }}
+  {{- if $subs.config }}
+  {{- if $subs.config.env }}
+  config:
+    env:
+  {{- range $subs.config.env }}
+      - name: {{ .name }}
+        value: {{ .value }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{- if $.Values.global.options.useCSV }}
   startingCSV: {{ $subs.csv }}
   {{- end }}
@@ -32,6 +42,16 @@ spec:
   sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
   channel: {{ default "stable" $subs.channel }}
   installPlanApproval: {{ coalesce  $installPlanValue $.Values.global.options.installPlanApproval }}
+  {{- if $subs.config }}
+  {{- if $subs.config.env }}
+  config:
+    env:
+  {{- range $subs.config.env }}
+      - name: {{ .name }}
+        value: {{ .value }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{- if $.Values.global.options.useCSV }}
   startingCSV: {{ $subs.csv }}
   {{- end }}


### PR DESCRIPTION
While testing deploying Industrial Edge on a FIPS mode the AMQ Streams operator was not deploying due to the FIPS mode.  There was a need to pass an environment variable to the operator so the way we do that is by defining the ENV in the manifest.

This PR partly implements the .spec.config.env found in the [4.10 Subscription Spec](https://docs.openshift.com/container-platform/4.10/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1.html).  It only implements the .spec.config.env[].name and .spec.config.env[].value and does not implement the .spec.config.env[].valueFrom.

A subscription in our values files can add environment variables in the subscription definition which will get passed to the subscription operator:
``` amqstreams-dev:
      name: amq-streams
      namespaces:
        - manuela-tst-all
      channel: amq-streams-2.x
      csv: amqstreams.v2.0.1-0
      config:
        env:
          - name: foo
            value: bar
          - name: "var"
            value: "value"
```

The VP Framework will generate the following:
```
---
# Source: pattern-clustergroup/templates/subscriptions.yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: amq-streams
  namespace: manuela-tst-all
spec:
  name: amq-streams
  source: redhat-operators
  sourceNamespace: openshift-marketplace
  channel: amq-streams-2.x
  installPlanApproval: Automatic
  config:
    env:
      - name: "foo"
        value: "bar"
      - name: "var"
        value: "value"
---
```
This can now be applied to the OpenShift cluster environment to create the subscription.