### PR TITLE
Revert "Move operator installation in patterns-operator-system namespace"

### DIFF
--- a/operator-install/templates/namespace.yaml
+++ b/operator-install/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.vpoperator.namespace }}

--- a/operator-install/templates/operator_group.yaml
+++ b/operator-install/templates/operator_group.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: patterns-operator
-  namespace: {{ .Values.vpoperator.namespace }}
-spec:

--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -2,7 +2,7 @@ apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Values.vpoperator.namespace }}
+  namespace: openshift-operators
 spec:
   clusterGroupName: {{ .Values.main.clusterGroupName }}
   gitSpec:

--- a/operator-install/templates/subscription.yaml
+++ b/operator-install/templates/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: {{ .Values.vpoperator.namespace }}
+  namespace: openshift-operators
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -1,6 +1,3 @@
-vpoperator:
-  namespace: patterns-operator-system
-
 main:
   git:
     repoURL: https://github.com/pattern-clone/mypattern

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -1,24 +1,10 @@
 ---
-# Source: pattern-install/templates/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: patterns-operator-system
----
-# Source: pattern-install/templates/operator_group.yaml
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: patterns-operator
-  namespace: patterns-operator-system
-spec:
----
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: operator-install
-  namespace: patterns-operator-system
+  namespace: openshift-operators
 spec:
   clusterGroupName: default
   gitSpec:
@@ -30,7 +16,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: patterns-operator-system
+  namespace: openshift-operators
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -1,24 +1,10 @@
 ---
-# Source: pattern-install/templates/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: patterns-operator-system
----
-# Source: pattern-install/templates/operator_group.yaml
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: patterns-operator
-  namespace: patterns-operator-system
-spec:
----
 # Source: pattern-install/templates/pattern.yaml
 apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
 kind: Pattern
 metadata:
   name: operator-install
-  namespace: patterns-operator-system
+  namespace: openshift-operators
 spec:
   clusterGroupName: example
   gitSpec:
@@ -30,7 +16,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: patterns-operator
-  namespace: patterns-operator-system
+  namespace: openshift-operators
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:


### PR DESCRIPTION
This reverts commit b175f751080d0bd2d272401e13d1dc6b042cf0b5.

It seems OLM's general direction is to want the initial namespace of an
operator to be 'openshift-operators'

This will leave us with a discrepancy between installing with the UI
and installing the operator via a rebuild and 'make deploy' but so be
it.
