### PR TITLE
WIP: Extend values-secret parsing to include files section

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+Vim filetype=yaml
+---
+offline: false
+
+warn_list:
+  - command-instead-of-shell

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,3 @@
 # Vim filetype=yaml
 ---
 offline: false
-
-warn_list:
-  - command-instead-of-shell

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,4 @@
-Vim filetype=yaml
+# Vim filetype=yaml
 ---
 offline: false
 

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -145,7 +145,7 @@
   ansible.builtin.set_fact:
     secret_files_vault_cmds: "{{ secret_files_vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
   vars:
-    vault_cmd: "cat '{{ item.value }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'vault kv put {{ vault_path }}/{{ item.key }} file=-'"
+    vault_cmd: "cat '{{ item.value }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'vault kv put {{ vault_path }}/{{ item.key }} content=-'"
   loop:
     "{{ file_secrets | dict2items }}"
   loop_control:

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -69,7 +69,7 @@
     var: file_stat
   when: debug | default(False) | bool
 
-- name: debug file_valaues
+- name: debug file_values
   ansible.builtin.debug:
     var: file_values
   when: debug | default(False) | bool
@@ -190,8 +190,9 @@
     label: "{{ item.key }}"
   when: not debug | default(False) | bool
 
+  # This has to be shell because of the use of stdin and pipes
 - name: Add the file secrets to the vault
-  ansible.builtin.shell:
+  ansible.builtin.shell: # noqa: command-instead-of-shell
     "{{ item.value }}"
   loop:
     "{{ secret_files_vault_cmds | dict2items }}"

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -31,17 +31,18 @@
     msg: "Was not able to parse any secrets from file {{ values_secret }}. 'secrets:' top-level key is missing"
   failed_when: "'secrets' not in all_values.keys()"
 
-- name: Set secrets fact
+- name: Set secrets and file_secrets facts
   ansible.builtin.set_fact:
-    secrets: "{{ all_values['secrets'] }}"
+    secrets: "{{ all_values['secrets'] | default({}) }}"
+    file_secrets: "{{ all_values['files'] | default({}) }}"
 
 - name: Verify we have any secrets at all
   ansible.builtin.fail:
     msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
   failed_when:
-    secrets is not defined or secrets | length == 0
+    secrets | combine(file_secrets) | length == 0
 
-- name: Check the value-secret.yaml file for errors
+- name: Check the value-secret.yaml file for errors in the secrets section
   ansible.builtin.fail:
     msg: >
       "{{ item }}" is not properly formatted. Each key under 'secrets:'
@@ -54,18 +55,33 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Check the value-secret.yaml file for errors
+- name: Validate file references in the files section of value-secret.yaml
+  ansible.builtin.stat:
+    path: '{{ file_stat.value }}'
+  register: file_values
+  loop_control:
+    loop_var: file_stat
+  loop:
+    "{{ file_secrets | dict2items }}"
+
+- name: debug file_stat
+  ansible.builtin.debug:
+    var: file_stat
+  when: debug | default(False) | bool
+
+- name: debug file_valaues
+  ansible.builtin.debug:
+    var: file_values
+  when: debug | default(False) | bool
+
+- name: Fail if referenced file does not exist
   ansible.builtin.fail:
     msg: >
-      "{{ item }}" is not properly formatted. Each key under 'secrets:'
-      needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
+      "file {{ item.file_stat.key }} {{ item.file_stat.value }}" must exist and be a file
   when: >
-    item.key | length == 0 or
-    item.value is not mapping
+    not item.stat.exists
   loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+    "{{ file_values.results }}"
 
 # Detect here if we have only the following two keys under a password
 # s3.accessKey: <accessKey>
@@ -114,7 +130,7 @@
 #    and https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py#L124
 # C. The \\A and \\Z match the beginning and end of a string (in case of multiline strings
 #    do not want to match every line)
-- name: Set vault commands fact
+- name: Set secrets vault commands fact
   ansible.builtin.set_fact:
     vault_cmds: "{{ vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
   vars:
@@ -125,9 +141,24 @@
   loop_control:
     label: "{{ item.key }}"
 
+- name: Set files vault commands fact
+  ansible.builtin.set_fact:
+    secret_files_vault_cmds: "{{ secret_files_vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
+  vars:
+    vault_cmd: "cat '{{ item.value }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'vault kv put {{ vault_path }}/{{ item.key }} file=-'"
+  loop:
+    "{{ file_secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
 - name: Debug vault commands
   ansible.builtin.debug:
     msg: "{{ vault_cmds }}"
+  when: debug | default(False) | bool
+
+- name: Debug files vault commands
+  ansible.builtin.debug:
+    msg: "{{ secret_files_vault_cmds }}"
   when: debug | default(False) | bool
 
 # This step is not really needed when running make vault-init + load-secrets as
@@ -155,6 +186,15 @@
       sh -c "{{ item.value }}"
   loop:
     "{{ vault_cmds | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: not debug | default(False) | bool
+
+- name: Add the file secrets to the vault
+  ansible.builtin.shell:
+    "{{ item.value }}"
+  loop:
+    "{{ secret_files_vault_cmds | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
   when: not debug | default(False) | bool


### PR DESCRIPTION
This extends values-secret.yaml parsing to allow entries of the form:

```
files:
  key: <filename>
```
Which requires that <filename> exist and be a valid file.

This will add secrets of the form:

secrets/<path>/key file=<file content>

This works by cat'ing the file into a pipe with oc exec.
