### PR TITLE
Support k8s 1.24

### DIFF
--- a/ansible/roles/vault_utils/defaults/main.yml
+++ b/ansible/roles/vault_utils/defaults/main.yml
@@ -17,6 +17,7 @@ vault_pki_max_lease_ttl: "8760h"
 output_file: "common/pattern-vault.init"
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
+external_secrets_secret: golang-external-secrets
 # Setting this to false makes the role store the vault unseal keys and root login
 # token inside a secret in the cluster.
 # *Note* that this is fundamentally unsafe

--- a/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -33,34 +33,14 @@
     command: "vault auth enable -path={{ vault_hub }} kubernetes"
   when: kubernetes_enabled.rc != 0
 
-- name: Fetch "{{ external_secrets_ns }}/{{ external_secrets_sa }} secret name"
-  kubernetes.core.k8s_info:
-    kind: ServiceAccount
-    namespace: "{{ external_secrets_ns }}"
-    name: "{{ external_secrets_sa }}"
-    api_version: v1
-  register: serviceaccount
-
-# FIXME: we could bail out nicely if secrets is empty
-- name: Get "{{ external_secret_sa }} secrets"
-  ansible.builtin.set_fact:
-    secrets: "{{ serviceaccount.resources[0].secrets }}"
-
-- name: Filter secrets of "{{ external_secrets_ns }}/{{ external_secrets_sa }}"
-  ansible.builtin.set_fact:
-    secret: "{{ item.name }}"
-  when: '"golang-external-secrets-token-" in item.name'
-  loop: "{{ secrets }}"
-
-- name: Get token of the secret
+- name: Get token
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
-    name: "{{ secret }}"
+    name: "{{ external_secrets_secret }}"
     api_version: v1
   register: token_data
 
-# FIXME: we could bail out nicely if token_data is empty
 - name: Set sa_token fact
   ansible.builtin.set_fact:
     sa_token: "{{ token_data.resources[0].data.token | b64decode }}"

--- a/golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -19,6 +19,7 @@ spec:
         kubernetes:
           mountPath: {{ .Values.mountPath }}
           role: {{ .Values.mountRole }}
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"

--- a/tests/golang-external-secrets-naked.expected.yaml
+++ b/tests/golang-external-secrets-naked.expected.yaml
@@ -52,6 +52,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     external-secrets.io/component : webhook
 ---
+# Source: golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 # Source: golang-external-secrets/charts/external-secrets/templates/crds/clusterexternalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5718,9 +5728,10 @@ spec:
         kubernetes:
           mountPath: hub
           role: hub-role
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"
 ---
 # Source: golang-external-secrets/charts/external-secrets/templates/validatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/tests/golang-external-secrets-normal.expected.yaml
+++ b/tests/golang-external-secrets-normal.expected.yaml
@@ -52,6 +52,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     external-secrets.io/component : webhook
 ---
+# Source: golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 # Source: golang-external-secrets/charts/external-secrets/templates/crds/clusterexternalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5718,9 +5728,10 @@ spec:
         kubernetes:
           mountPath: hub
           role: hub-role
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"
 ---
 # Source: golang-external-secrets/charts/external-secrets/templates/validatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
In kubernetes 1.24 (OCP 4.11) the token for service account does not get
created anymore [1]. In order to support all of our supported OCP versions
with the least effort, we just create a secret and associate it to the
golang-external-secret service account.

While we're at it we simplify the ansible a code a bit and simply always
rely on having the golang-external-secrets secret created by default.

Tested on OCP 4.8, 4.9, 4.10 and 4.11. In all tests I saw the
config-demo-secret being created inside the cluster and 'make install'
succeeded correctly.

Closes: https://issues.redhat.com/browse/MBP-321

[1] https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation=
