### PR TITLE
Change conditionals on imperative framework

### DIFF
--- a/clustergroup/templates/imperative/clusterrole.yaml
+++ b/clustergroup/templates/imperative/clusterrole.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/clustergroup/templates/imperative/configmap.yaml
+++ b/clustergroup/templates/imperative/configmap.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 {{- $valuesyaml := toYaml $.Values -}}
 apiVersion: v1
 kind: ConfigMap

--- a/clustergroup/templates/imperative/job.yaml
+++ b/clustergroup/templates/imperative/job.yaml
@@ -1,5 +1,5 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined */}}
+{{- if (gt (len $.Values.clusterGroup.imperative.jobs) 0) -}}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/clustergroup/templates/imperative/namespace.yaml
+++ b/clustergroup/templates/imperative/namespace.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clustergroup/templates/imperative/rbac.yaml
+++ b/clustergroup/templates/imperative/rbac.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/clustergroup/templates/imperative/role.yaml
+++ b/clustergroup/templates/imperative/role.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/clustergroup/templates/imperative/serviceaccount.yaml
+++ b/clustergroup/templates/imperative/serviceaccount.yaml
@@ -1,5 +1,6 @@
-{{/* Only define this if there are any imperativejobs defined */}}
-{{- if gt (len $.Values.clusterGroup.imperative.jobs) 0 -}}
+{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
+{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
+    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
 {{- if $.Values.clusterGroup.imperative.serviceAccountCreate -}}
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The change in structure is needed because there are two things that require the creation of the imperative role/clusterrole/namespace/rbac:

1) A request for an imperative job
2) A request for the insecure vault unseal operation

These may occur together or separately; an unseal without a job in the old scheme would fail because the role/namespace etc was not created for it