### PR TITLE
Allow ha vault deployments

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_delete.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_delete.yaml
@@ -1,5 +1,6 @@
 ---
 - include_tasks: pre_check.yaml
+- include_tasks: vault_status.yaml
 
 # Note: We do not wait on purpose here as the pod will be recreated
 # anyways and that would race. We are fine with having it gone once
@@ -9,7 +10,8 @@
     api_version: v1
     kind: Pod
     namespace: "{{ vault_ns }}"
-    name: "{{ vault_pod }}"
+    name: "{{ item }}"
+  loop: "{{ vault_pods }}"
 
 - name: Delete vault pvc
   kubernetes.core.k8s:
@@ -17,4 +19,5 @@
     api_version: v1
     kind: PersistentVolumeClaim
     namespace: "{{ vault_ns }}"
-    name: "{{ vault_pvc }}"
+    name: "data-{{ item }}"
+  loop: "{{ vault_pods }}"

--- a/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -33,13 +33,14 @@
     command: "vault auth enable -path={{ vault_hub }} kubernetes"
   when: kubernetes_enabled.rc != 0
 
-- name: Get token
+- name: Get token from service account secret {{ external_secrets_ns }}/{{ external_secrets_secret }}
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
     name: "{{ external_secrets_secret }}"
     api_version: v1
   register: token_data
+  failed_when: token_data.resources | length == 0
 
 - name: Set sa_token fact
   ansible.builtin.set_fact:

--- a/ansible/roles/vault_utils/tasks/vault_status.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_status.yaml
@@ -38,3 +38,19 @@
   ansible.builtin.set_fact:
     vault_status: "{{ vault_status_json.stdout | from_json }}"
   when: vault_status_json.stdout_lines | length > 0
+
+- name: List Vault pods
+  kubernetes.core.k8s_info:
+    namespace: "{{ vault_ns }}"
+    kind: Pod
+    label_selectors:
+      - "component = server"
+  register: vault_pods_list
+
+- name: "Get pods"
+  set_fact:
+    vault_pods: "{{ vault_pods_list | json_query(\"resources[].metadata.name\") }}"
+
+- name: "Followers"
+  set_fact:
+    followers: "{{ vault_pods | difference(vault_pod) }}"

--- a/ansible/roles/vault_utils/tasks/vault_status.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_status.yaml
@@ -48,9 +48,12 @@
   register: vault_pods_list
 
 - name: "Get pods"
-  set_fact:
-    vault_pods: "{{ vault_pods_list | json_query(\"resources[].metadata.name\") }}"
+  ansible.builtin.set_fact:
+    vault_pods: "{{ vault_pods + [item.metadata.name] }}"
+  loop: "{{ vault_pods_list.resources }}"
+  vars:
+    vault_pods: []
 
 - name: "Followers"
-  set_fact:
+  ansible.builtin.set_fact:
     followers: "{{ vault_pods | difference(vault_pod) }}"

--- a/ansible/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_unseal.yaml
@@ -67,7 +67,7 @@
     unseal_keys: "{{ vault_init_json['unseal_keys_hex'] }}"
   when: vault_sealed
 
-- name: Unseal vault
+- name: Unseal leader
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
@@ -77,6 +77,32 @@
     extended: true
     label: "Unsealing with key {{ ansible_loop.index }}"
   when: vault_sealed
+
+- name: Join Raft cluster
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ item }}"
+    command: vault operator raft join http://{{ vault_pod }}.{{ vault_ns }}-internal:8200
+  loop: "{{ followers }}"
+  loop_control:
+    extended: true
+    label: "Joining Raft Cluster on http://{{ vault_pod }}.{{ vault_ns }}-internal:8200"
+  when:
+    - vault_sealed
+    - followers | length > 0
+
+- name: Unseal followers
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ item.0 }}"
+    command: vault operator unseal "{{ item.1 }}"
+  loop: "{{ followers|product(unseal_keys)|list }}"
+  loop_control:
+    extended: true
+    label: "Unsealing {{ item.0 }} with key {{ ansible_loop.index }}"
+  when:
+    - vault_sealed
+    - followers | length > 0
 
 - name: Login into vault
   kubernetes.core.k8s_exec:

--- a/ansible/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_unseal.yaml
@@ -96,7 +96,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ item.0 }}"
     command: vault operator unseal "{{ item.1 }}"
-  loop: "{{ followers|product(unseal_keys)|list }}"
+  loop: "{{ followers | product(unseal_keys) | list }}"
   loop_control:
     extended: true
     label: "Unsealing {{ item.0 }} with key {{ ansible_loop.index }}"


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

Detect if vault deployments has more pods and assume `vault-0` as the leader.
Make the other `vault-x` join the raft cluster as followers and finally unseal the followers.

Additionally: Added check for missing serviceAccount token secret