### PR TITLE
Silence Get Pods loop a bit

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_status.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_status.yaml
@@ -51,6 +51,9 @@
   ansible.builtin.set_fact:
     vault_pods: "{{ vault_pods + [item.metadata.name] }}"
   loop: "{{ vault_pods_list.resources }}"
+  loop_control:
+    extended: true
+    label: "{{ ansible_loop.index }}"
   vars:
     vault_pods: []
 


### PR DESCRIPTION
Otherwise we get the printout of all the metadata returned by the pod
list call. Tested on an MCG cluster.
