### PR TITLE
Print the name of the pod when getting pods

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_status.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_status.yaml
@@ -52,8 +52,7 @@
     vault_pods: "{{ vault_pods + [item.metadata.name] }}"
   loop: "{{ vault_pods_list.resources }}"
   loop_control:
-    extended: true
-    label: "{{ ansible_loop.index }}"
+    label: "{{ item.metadata.name }}"
   vars:
     vault_pods: []
 


### PR DESCRIPTION
This will make things a bit simpler to debug as the index is not very
interesting. Also remove the extended loop as it just uses up memory
needlessly
