### PR TITLE
Call expanduser on file to match stat behavior

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -152,7 +152,7 @@
   ansible.builtin.set_fact:
     secret_files_vault_cmds: "{{ secret_files_vault_cmds | combine({ item.key: vault_cmd}) }}"
   vars:
-    vault_cmd: "cat '{{ item.value }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'cat - > /tmp/vault_content'; oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'base64 --wrap=0 /tmp/vault_content | vault kv put {{ vault_path }}/{{ item.key }} b64content=- content=@/tmp/vault_content; rm /tmp/vault_content'" # noqa yaml
+    vault_cmd: "cat '{{ item.value | expanduser }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'cat - > /tmp/vault_content'; oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'base64 --wrap=0 /tmp/vault_content | vault kv put {{ vault_path }}/{{ item.key }} b64content=- content=@/tmp/vault_content; rm /tmp/vault_content'" # noqa yaml
   loop:
     "{{ file_secrets | dict2items }}"
   loop_control:


### PR DESCRIPTION
Users may want to specify their "file" secrets using ~, which causes confusing behavior in Ansible, since ansible stat calls the expanduser filter on its path (causing the lookup of such a file to succeed), but then we call `cat` on it when loading it (in single quotes) which does not have that behavior.

This change normalizes the behaviors between the different sections of the task.