### PR TITLE
Allow configuring clusters with ExternalSecrets

### DIFF
--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -117,7 +117,7 @@ metadata:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
-    name: in-cluster
+    name: {{ coalesce .clusterName "in-cluster" }}
     namespace: {{ default $namespace .namespace }}
   project: {{ .project }}
   source:

--- a/clustergroup/templates/cluster-external-secrets.yaml
+++ b/clustergroup/templates/cluster-external-secrets.yaml
@@ -1,0 +1,26 @@
+{{- $namespace := cat $.Values.global.pattern $.Values.clusterGroup.name | replace " " "-" }}
+{{ if .Values.clusterGroup.isHubCluster }}
+{{- range .Values.clusterGroup.externalClusters }}
+---
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: {{ . | kebabcase }}-secret
+  namespace: {{ $namespace }}
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: {{ $.Values.secretStore.name }}
+    kind: {{ $.Values.secretStore.kind }}
+  target:
+    name: {{ . | kebabcase }}-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+  dataFrom:
+  - extract:
+      key: {{ $.Values.secretsBase.key }}/cluster_{{ . }}
+{{- end }}
+{{ end }}

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -41,6 +41,15 @@ clusterGroup:
     roleName: imperative-role
     roleYaml: ""
 
+secretStore:
+  name: vault-backend
+  kind: ClusterSecretStore
+
+# Depends on the value of 'vault_hub' ansible variable used 
+# during the installation
+secretsBase:
+  key: secret/data/hub
+
 #  managedClusterGroups:
 #  - name: factory
 #    # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -47,6 +47,11 @@ clusterGroup:
       namespace: application-ci
       project: datacenter
       path: charts/datacenter/pipelines
+    external:
+      name: external-app
+      namespace: demo
+      project: datacenter
+      clusterName: example
 
   managedClusterGroups:
   - name: edge

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -67,3 +67,7 @@ clusterGroup:
         values:
           - OpenShift
 
+  # Create an ExternalSecret with a label that ArgoCD
+  # will detect and register as a new Cluster
+  externalClusters:
+    - example # Will read the key: cluster_example

--- a/examples/values-secret.yaml
+++ b/examples/values-secret.yaml
@@ -17,5 +17,21 @@ secrets:
   aws:
     s3Secret: test-secret
 
-
-
+  # The cluster_xxxx pattern is used for creating externalSecrets that
+  # will be used by ArgoCD to detect other clusters.
+  #
+  # Create a service account with enough permissions and extract the token
+  #
+  # CLUSTER_TOKEN=$(oc describe secret -n default argocd-external-token | grep 'token:' | awk '{print$2}')
+  # CLUSTER_CA=$(oc extract -n openshift-config cm/kube-root-ca.crt --to=- --keys=ca.crt | base64 | awk '{print}' ORS='')
+  cluster_example:
+    name: example
+    server: https://api.example.openshiftapps.com:6443
+    config: |
+      {
+        \"bearerToken\": \"<bearer_token>\",
+        \"tlsClientConfig\": {
+          \"insecure\": false,
+          \"caData\": \"<base64 encoded CA>\"
+        }
+      }

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -68,6 +68,11 @@ data:
           namespace: open-cluster-management
           path: common/acm
           project: datacenter
+        external:
+          clusterName: example
+          name: external-app
+          namespace: demo
+          project: datacenter
         pipe:
           name: pipelines
           namespace: application-ci
@@ -498,6 +503,46 @@ spec:
     "kind": "ManagedClusterInfo"
   }
 ]
+  syncPolicy:
+    automated: {}
+    #  selfHeal: true
+---
+# Source: pattern-clustergroup/templates/applications.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-app
+  namespace: mypattern-example
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  destination:
+    name: example
+    namespace: demo
+  project: datacenter
+  source:
+    repoURL: https://github.com/pattern-clone/mypattern
+    targetRevision: 
+    path: 
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+      - "/values-global.yaml"
+      - "/values-example.yaml"
+      # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
+      parameters:
+        - name: global.repoURL
+          value: $ARGOCD_APP_SOURCE_REPO_URL
+        - name: global.targetRevision
+          value: $ARGOCD_APP_SOURCE_TARGET_REVISION
+        - name: global.namespace
+          value: $ARGOCD_APP_NAMESPACE
+        - name: global.pattern
+          value: mypattern
+        - name: global.hubClusterDomain
+          value: hub.example.com
+        - name: global.localClusterDomain
+          value: region.example.com
   syncPolicy:
     automated: {}
     #  selfHeal: true

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -73,6 +73,8 @@ data:
           namespace: application-ci
           path: charts/datacenter/pipelines
           project: datacenter
+      externalClusters:
+      - example
       imperative:
         activeDeadlineSeconds: 3600
         clusterRoleName: imperative-cluster-role
@@ -147,15 +149,31 @@ data:
       git:
         repoURL: https://github.com/pattern-clone/mypattern
         revision: main
+    secretStore:
+      kind: ClusterSecretStore
+      name: vault-backend
     secrets:
       aws:
         s3Secret: test-secret
+      cluster_example:
+        config: |-
+          {
+            \"bearerToken\": \"<bearer_token>\",
+            \"tlsClientConfig\": {
+              \"insecure\": false,
+              \"caData\": \"<base64 encoded CA>\"
+            }
+          }
+        name: example
+        server: https://api.example.openshiftapps.com:6443
       git:
         token: test-git-token
         username: test-user
       imageregistry:
         account: test-account
         token: test-quay-token
+    secretsBase:
+      key: secret/data/hub
 ---
 # Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -648,6 +666,28 @@ spec:
   href: 'https://example-gitops-server-mypattern-example.region.example.com'
   location: ApplicationMenu
   text: 'Example ArgoCD'
+---
+# Source: pattern-clustergroup/templates/cluster-external-secrets.yaml
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: example-secret
+  namespace: mypattern-example
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: example-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+  dataFrom:
+  - extract:
+      key: secret/data/hub/cluster_example
 ---
 # Source: pattern-clustergroup/templates/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

This is a suggested feature that I decided to use for registering new clusters in ArgoCD instead of using ACM.

By creating ExternalSecrets with a specific label in them, ArgoCD can add them to its configuration. This reduces the technical footprint for cases in which ACM is not necessary.

Check the parameters that are now part of the default configuration.