### PR TITLE
Standardize sync-policy handling 

### DIFF
--- a/clustergroup/templates/applications.yaml
+++ b/clustergroup/templates/applications.yaml
@@ -147,11 +147,13 @@ spec:
   {{- if .ignoreDifferences }}
   ignoreDifferences: {{ .ignoreDifferences | toPrettyJson }}
   {{- end }}
-{{- if eq $.Values.global.options.syncPolicy "Automatic" }}
+  {{- if .syncPolicy }}
+  syncPolicy: {{ .syncPolicy | toPrettyJson }}
+  {{- else }}
   syncPolicy:
     automated: {}
     #  selfHeal: true
-{{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This effectively deprecates the variable global.options.syncPolicy but this is the only place we were using it, and we weren't checking syncPolicy here either. This standardizes usage without changing behavior.