### PR TITLE
Only create managedclustersets if there are clusterpools

### DIFF
--- a/acm/templates/provision/clusterpool.yaml
+++ b/acm/templates/provision/clusterpool.yaml
@@ -1,5 +1,6 @@
 {{- range .Values.clusterGroup.managedClusterGroups }}
 {{- $group := . }}
+{{- if .clusterPools }}{{- /* We only create ManagedClusterSets if there are clusterPools defined */}}
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: ManagedClusterSet
 metadata:
@@ -77,8 +78,7 @@ metadata:
 spec:
   clusterPoolName: {{ $pool.name }}
 ---
-{{- end }}
-{{- end }}
-{{- end }}
-
-  
+{{- end }}{{- /* range .range clusters */}}
+{{- end }}{{- /* range .clusterPools */}}
+{{- end }}{{- /* if .clusterPools) */}}
+{{- end }}{{- /* range .Values.clusterGroup.managedClusterGroups */}}

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -1,15 +1,4 @@
 ---
-# Source: acm/templates/provision/clusterpool.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
-kind: ManagedClusterSet
-metadata:
-  annotations:
-    cluster.open-cluster-management.io/submariner-broker-ns: edge-broker
-  name: edge
-spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel
----
 # Source: acm/templates/multiclusterhub.yaml
 apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub


### PR DESCRIPTION
Otherwise we end up with the following error whenever we have
managedClusters that do not have clusterpools defined in them:

cluster.open-cluster-management.io/v1beta1/ManagedClusterSet open-cluster-management region-one SyncFailed the server could not find the requested resource
