### PR TITLE
Add operatorchannel parameter

### DIFF
--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -8,3 +8,5 @@ spec:
   gitSpec:
     targetRepo: {{ .Values.main.git.repoURL }}
     targetRevision: {{ .Values.main.git.revision }}
+  gitOpsSpec:
+    operatorChannel: {{ default "stable" .Values.main.gitops.channel }}

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -3,4 +3,7 @@ main:
     repoURL: https://github.com/pattern-clone/mypattern
     revision: main
 
+  gitops:
+    channel: "stable"
+
   clusterGroupName: default

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -10,6 +10,8 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
+  gitOpsSpec:
+    operatorChannel: stable
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -10,6 +10,8 @@ spec:
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
+  gitOpsSpec:
+    operatorChannel: stable
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Add support for mapping .Values.main.gitops.channel for operator installs. Default to "stable".