### PR TITLE
Move CSV definition into the uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set glo
 	--set clusterGroup.insecureUnsealVaultInsideCluster=true
 PATTERN_OPTS=-f common/examples/values-example.yaml
 EXECUTABLES=git helm oc ansible
-CSV=$(shell oc get subscriptions -n openshift-operators openshift-gitops-operator -ojsonpath={.status.currentCSV})
 
 .PHONY: help
 help: ## This help message
@@ -70,6 +69,7 @@ operator-deploy operator-upgrade: validate-origin ## runs helm install
 	helm upgrade --install $(NAME) common/operator-install/ $(HELM_OPTS)
 
 uninstall: ## runs helm uninstall
+	$(eval CSV := $(shell oc get subscriptions -n openshift-operators openshift-gitops-operator -ojsonpath={.status.currentCSV}))
 	helm uninstall $(NAME)
 	@oc delete csv -n openshift-operators $(CSV)
 


### PR DESCRIPTION
Let's not call oc too many times for every invocation.
Moving the CSV variable definition inside the uninstall avoids that.
