### PR TITLE
Use dry-run when running tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ OUTPUT=${TESTDIR}/.${name}-${TEST_VARIANT}.expected.yaml
 #OUTPUT=${TESTDIR}/.${name}.expected.yaml
 
 echo "Testing $1 chart (${TEST_VARIANT})" >&2
-helm template $target --name-template $name ${CHART_OPTS} > ${OUTPUT}
+helm template --dry-run $target --name-template $name ${CHART_OPTS} > ${OUTPUT}
 rc=$?
 if [ $rc -ne 0 ]; then
     echo "FAIL on helm template $target --name-template $name ${CHART_OPTS}"


### PR DESCRIPTION
This should help avoiding surprises when KUBECONFIG is set or
~/.kube/config exists
