### PR TITLE
Unset KUBECONFIG and specify a non existing kubeconfig file when running tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# helm template (even with --dry-run) can interact with the cluster
+# This won't protect us if a user has ~/.kube
+# Also call helm template with a non existing --kubeconfig while we're at it
+unset KUBECONFIG
+
 target=$1
 name=$(echo $1 | sed -e s@/@-@g -e s@charts-@@)
 TEST_VARIANT="$2"
@@ -11,7 +17,7 @@ OUTPUT=${TESTDIR}/.${name}-${TEST_VARIANT}.expected.yaml
 #OUTPUT=${TESTDIR}/.${name}.expected.yaml
 
 echo "Testing $1 chart (${TEST_VARIANT})" >&2
-helm template $target --name-template $name ${CHART_OPTS} > ${OUTPUT}
+helm template --kubeconfig /tmp/doesnotexistever $target --name-template $name ${CHART_OPTS} > ${OUTPUT}
 rc=$?
 if [ $rc -ne 0 ]; then
     echo "FAIL on helm template $target --name-template $name ${CHART_OPTS}"


### PR DESCRIPTION
This should help avoiding surprises when KUBECONFIG is set and helm
produces different results.
