### PR TITLE
Disable ansible linting in the super-linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ super-linter: ## Runs super linter locally
 					-e VALIDATE_JSCPD=false \
 					-e VALIDATE_KUBERNETES_KUBEVAL=false \
 					-e VALIDATE_YAML=false \
+					-e VALIDATE_ANSIBLE=false \
 					$(DISABLE_LINTERS) \
 					-v $(PWD):/tmp/lint:rw,z docker.io/github/super-linter:slim-v4
 


### PR DESCRIPTION
This does it in common/ so we can simplify pattern's makefiles
We have ansible-lint that covers things linting-wise.
