### PR TITLE
Implement a per-subscription csv field

### DIFF
--- a/clustergroup/templates/subscriptions.yaml
+++ b/clustergroup/templates/subscriptions.yaml
@@ -27,6 +27,8 @@ spec:
   {{- end }}
   {{- if $.Values.global.options.useCSV }}
   startingCSV: {{ $subs.csv }}
+  {{- else if $subs.csv }}
+  startingCSV: {{ $subs.csv }}
   {{- end }}
 ---
 {{- end }}
@@ -53,6 +55,8 @@ spec:
   {{- end }}
   {{- end }}
   {{- if $.Values.global.options.useCSV }}
+  startingCSV: {{ $subs.csv }}
+  {{- else if $subs.csv }}
   startingCSV: {{ $subs.csv }}
   {{- end }}
 ---

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -766,6 +766,7 @@ spec:
   sourceNamespace: openshift-marketplace
   channel: release-2.4
   installPlanApproval: Automatic
+  startingCSV: advanced-cluster-management.v2.4.1
 ---
 # Source: pattern-clustergroup/templates/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -779,3 +780,4 @@ spec:
   sourceNamespace: openshift-marketplace
   channel: stable
   installPlanApproval: Automatic
+  startingCSV: redhat-openshift-pipelines.v1.5.2


### PR DESCRIPTION
Currently a user can only get the global.options.useCSV to true
(defaults to false) and once it is set to true *all* subscrptions
will get their 'startingCSV' fields populated with whatever is set in
the 'csv' subscription field. So all subscriptions *must* have a csv
field set.

With this change we can add a per-subscription useCSV toggle which
allows us to do this case by case.
A use-case here is to pass something like the following:

  subscriptions:
    amqstreams-dev:
      name: amq-streams
      namespace: manufacturing-dev
      channel: amq-streams-1.8.x
      csv: amqstreams.v1.8.0
      installPlanApproval: Manual

The above will make sure the startingCSV is amqstreams.v1.8.0 *only* for
the amq-streams operator, and it will make the installation manual.
So once the manual installation is approved we get v1.8.0 installed.

The caveat is that this is really dependent on how each operator
implements the allowed versions and their lifecycle.

Tested it with the above subscription so and correctly got amq-streams
v1.8.0 after approving manually. The other subscriptions without .csv
had no "startingCSV" field in the Subscription object.

Co-Authored-By: Lester Claudio <claudiol@redhat.com>
