### PR TITLE
Revert parts of 8e332950dc (Move the cluster provisioning into the acm chart)

### DIFF
--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -119,7 +119,6 @@ spec:
     {{- range .labels }}
       {{ .name }}: {{ .value }}
     {{- end }}
-      patternGroup: {{ $group.name }}
   {{- end }}
 ---
 {{- end }}

--- a/acm/templates/provision/clusterpool.yaml
+++ b/acm/templates/provision/clusterpool.yaml
@@ -74,7 +74,6 @@ metadata:
     {{- range $group.labels }}
     {{ .name }}: {{ .value }}
     {{- end }}
-    patternGroup: {{ $group.name }}
 spec:
   clusterPoolName: {{ $pool.name }}
 ---


### PR DESCRIPTION
This will create the following PlacementRule:

  kind: PlacementRule
  metadata:
    labels:
      argocd.argoproj.io/instance: acm
    name: region-one-placement
    namespace: open-cluster-management
  spec:
    clusterConditions:
      - status: 'True'
	type: ManagedClusterConditionAvailable
    clusterSelector:
      matchLabels:
	clusterGroup: region-one
	patternGroup: region-one

And since nowhere did we ever document that the remote clusters now need
two labels (patternGroup *and* clusterGroup) I am reverting this for
now as it makes the placement rules not work.
