### PR TITLE
Update for subscription.yaml template in common/clustergroup

### DIFF
--- a/clustergroup/templates/subscriptions.yaml
+++ b/clustergroup/templates/subscriptions.yaml
@@ -3,6 +3,7 @@
 {{- $installPlanValue := .installPlanApproval }}
 
 {{- if $subs.namespaces }}
+{{- if not $subs.disabled }}
 {{- range .namespaces }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -31,6 +32,7 @@ spec:
   startingCSV: {{ $subs.csv }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- else if not $subs.disabled }}
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
We added a feature, a while ago, to allow the user to disable the subscription if desired. Adding
the *disable: true* key/value pair to the definition of the subscription would skip the generation
of the subscription manifest.

There are two ways to describe subscriptions in our values-*.yaml file.
The first way is to define a subscription to be targeted to one namespace:

    seldon-dev:
      name: seldon-operator
      namespace: manuela-tst-all
      source: community-operators
      csv: seldon-operator.v1.12.0

The second way of define a subscription is to target multiple namespaces.  This means that
the subcription will get applied to each namespace listed:

    seldon:
      disabled: true
      name: seldon-operator
      namespaces:
      - manuela-ml-workspace
      - manuela-tst-all
      source: community-operators
      csv: seldon-operator.v1.12.0

The current template implementation for subscription would only allow disabling subscription
defined in a single namespace. This commit will allow users to disable subscription definitions
targeted to multiple namespaces.
