### PR TITLE
Drop readlink -f usage

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -4,6 +4,12 @@ if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/hybridcloudpatterns-utility-ee"
 fi
 
+# This is one of the most concise ways to get a readlink -f command work without going too complicated
+# Across Linux and MacOSX
+function real_path() {
+       echo $(cd $(dirname $1) ; pwd -P)
+}
+
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # /home/runner is the normal homedir
 # $HOME is mounted as itself for any files that are referenced with absolute paths
@@ -11,7 +17,7 @@ fi
 # We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
 SSH_SOCK_MOUNTS=""
 if [ -n "$SSH_AUTH_SOCK" ]; then
-	SSH_SOCK_MOUNTS="-v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+	SSH_SOCK_MOUNTS="-v $(real_path $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
 fi
 
 podman run -it \


### PR DESCRIPTION
And replace it with an echo + pwd combo that works both on Linux
and on Mac OSX.

Note that at this point the Mac OSX support is still not working
with ssh auth due to podman not being able to bind mount host dirs into
the container on the podman machine vm (or at least not /private/tmp)

Tested on both Fedora and Mac OSX
