### PR TITLE
Validated Patterns Schema Validation Update

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -30,19 +30,6 @@
             ],
             "title": "ValidatedPatterns"
         },
-        "Main": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "clusterGroupName": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "clusterGroupName"
-            ],
-            "title": "Main"
-        },
         "SecretsBase": {
             "type": "object",
             "additionalProperties": false,

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -1,0 +1,498 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/ValidatedPatterns",
+    "definitions": {
+        "ValidatedPatterns": {
+		    "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "secretsBase": {
+                    "$ref": "#/definitions/SecretsBase"
+                },
+                "secretStore": {
+                    "$ref": "#/definitions/SecretStore"
+                },
+                "secrets": {
+                    "$ref": "#/definitions/Secrets"
+                },
+                "main": {
+                    "$ref": "#/definitions/Main"
+                },
+                "global": {
+                    "$ref": "#/definitions/Global"
+                },
+                "clusterGroup": {
+                    "$ref": "#/definitions/ClusterGroup"
+                }
+            },
+            "required": [
+                "clusterGroup"
+            ],
+            "title": "ValidatedPatterns"
+        },
+        "Main": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "clusterGroupName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "clusterGroupName"
+            ],
+            "title": "Main"
+        },
+        "SecretsBase": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "type": "string"
+                }
+			},
+            "required": [
+			  "key"
+			],
+            "title": "SecretsBase"
+        },
+        "SecretStore": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                }
+			},
+            "required": [
+              "name",
+			  "kind"
+			],
+            "title": "SecretsStore"
+        },
+        "Secrets": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "imageregistry": {
+                    "$ref": "#/definitions/ImageRegistry"
+                },
+                "git": {
+                    "$ref": "#/definitions/GitSecrets"
+                }
+			},
+            "required": [],
+            "title": "Secrets"
+        },
+        "ImageRegistry": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "account": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+			},
+            "required": [
+                "account",
+				"token"
+            ],
+            "title": "ImageRegistry"
+        },
+        "GlobalGit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostname": {
+                    "type": "string"
+                },
+                "account": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "dev_revision": {
+                    "type": "string"
+                }
+			},
+            "required": [
+                "hostname",
+                "account",
+				"email"
+            ],
+            "title": "GlobalGit"
+        },
+        "GitSecrets": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "username": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+			},
+            "required": [
+                "username",
+				"token"
+            ],
+            "title": "GitSecrets"
+        },
+        "Main": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "clusterGroupName": {
+                    "type": "string"
+                },
+                "hubClusterDomain": {
+                    "type": "string"
+                },
+                "localClusterDomain": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "clusterGroupName"
+            ],
+            "title": "Main"
+        },
+        "Global": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pattern": {
+                    "type": "string"
+                },
+                "localClusterDomain": {
+                    "type": "string"
+                },
+                "hubClusterDomain": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "repoURL": {
+                    "type": "string"
+                },
+                "git": {
+                    "$ref": "#/definitions/GlobalGit"
+                },
+                "options": {
+                    "$ref": "#/definitions/Options"
+                }
+            },
+            "required": [
+                "options",
+                "pattern"
+            ],
+            "title": "Global"
+        },
+        "Options": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "useCSV": {
+                    "type": "boolean"
+                },
+                "syncPolicy": {
+                    "type": "string"
+                },
+                "installPlanApproval": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "installPlanApproval",
+                "syncPolicy",
+                "useCSV"
+            ],
+            "title": "Options"
+        },
+        "ClusterGroup": {
+		    "type": "object",
+			"additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "isHubCluster": {
+                    "type": "boolean"
+                },
+                "insecureUnsealVaultInsideCluster": {
+                    "type": "boolean"
+                },
+                "namespaces": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subscriptions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Subscription"
+                    }
+                },
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "applications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Application"
+                    }
+                },
+                "imperative": {
+                    "$ref": "#/definitions/Imperative"
+                },
+                "managedClusterGroups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ManagedClusterGroup"
+                    }
+                },
+                "externalClusters": {
+                    "type": "array"
+                }
+            },
+            "required": [
+                "applications",
+                "imperative",
+                "insecureUnsealVaultInsideCluster",
+                "isHubCluster",
+                "managedClusterGroups",
+                "name",
+                "namespaces",
+                "projects",
+                "subscriptions"
+            ],
+            "title": "ClusterGroup"
+        },
+        "Application": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "project": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "namespace",
+                "path",
+                "project"
+            ],
+            "title": "Application"
+        },
+        "Imperative": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "jobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Job"
+                    }
+                },
+				"image": {
+					"type": "string",
+					"default": "registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest"
+                },
+				"namespace": {
+					"type": "string",
+					"default": "imperative",
+					"enum": ["imperative"]
+                },
+				"serviceAccountCreate": {
+                    "type": "boolean"
+                },
+				"valuesConfigMap": {
+					"type": "string"
+                },
+				"cronJobName": {
+					"type": "string"
+                },
+				"jobName": {
+					"type": "string"
+                },
+				"imagePullPolicy": {
+					"type": "string",
+					"default": "Always",
+					"enum": ["Always", "IfNotPresent", "Never"]
+                },
+				"activeDeadlineSeconds": {
+					"type": "integer",
+					"default": 3600
+                },
+				"schedule": {
+					"type": "string",
+					"default": "*/10 * * * *"
+                },
+				"insecureUnsealVaultInsideClusterSchedule": {
+					"type": "string",
+				    "default": "*/5 * * * *"
+                },
+				"verbosity": {
+					"type": "string",
+					"default": "",
+					"enum": ["","-v", "-vv", "-vvv", "-vvvv"]
+                },
+				"serviceAccountName": {
+					"type": "string"
+                },
+				"clusterRoleName": {
+					"type": "string"
+                },
+				"clusterRoleYaml": {
+					"type": "string"
+                },
+				"roleName": {
+					"type": "string"
+                },
+				"roleYaml": {
+					"type": "string"
+                }
+            },
+            "required": [
+                "jobs",
+                "valuesConfigMap",
+                "cronJobName",
+                "jobName",
+                "activeDeadlineSeconds",
+                "schedule"
+            ],
+            "title": "Imperative"
+        },
+        "Job": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "playbook": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                },
+                "verbosity": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "playbook"
+            ],
+            "title": "Job"
+        },
+        "ManagedClusterGroup": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Label"
+                    }
+                },
+                "helmOverrides": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/HelmOverride"
+                    }
+                }
+            },
+            "required": [
+            ],
+            "title": "ManagedClusterGroup"
+        },
+        "HelmOverride": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ],
+            "title": "HelmOverride"
+        },
+        "Label": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ],
+            "title": "Label"
+        },
+        "Subscription": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "channel": {
+                    "type": "string"
+                },
+                "csv": {
+                    "type": "string"
+                },
+                "disabled": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name",
+                "channel"
+            ],
+            "title": "Subscription"
+        }
+    }
+}

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -13,6 +13,30 @@ clusterGroup:
   # is fundamentally insecure
   insecureUnsealVaultInsideCluster: false
 
+  namespaces:
+  - open-cluster-management
+
+  subscriptions:
+  - name: advanced-cluster-management
+    namespace: open-cluster-management
+    channel: release-2.5
+    csv: advanced-cluster-management.v2.5.0
+
+  projects:
+  - hub
+  - config-demo
+
+  applications:
+  - name: acm
+    namespace: open-cluster-management
+    project: hub
+    path: common/acm
+    ignoreDifferences:
+    - group: internal.open-cluster-management.io
+      kind: ManagedClusterInfo
+      jsonPointers:
+        - /spec/loggingCA
+
   imperative:
     jobs: []
     # This image contains ansible + kubernetes.core by default and is used to run the jobs
@@ -41,6 +65,21 @@ clusterGroup:
     roleName: imperative-role
     roleYaml: ""
 
+  managedClusterGroups:
+  - name: factory
+    labels:
+    - name: clusterGroup
+      value: region-one
+    helmOverrides:
+    - name: clusterGroup.isHubCluster
+      value: "false"
+    clusterSelector:
+      matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+#
 secretStore:
   name: vault-backend
   kind: ClusterSecretStore
@@ -49,22 +88,6 @@ secretStore:
 # during the installation
 secretsBase:
   key: secret/data/hub
-
-#  managedClusterGroups:
-#  - name: factory
-#    # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git
-#    # Location of values-global.yaml, values-{name}.yaml, values-{app}.yaml
-#    targetRevision: main
-#    path: applications/factory
-#    helmOverrides:
-#    - name: clusterGroup.isHubCluster
-#      value: false
-#    clusterSelector:
-#      matchExpressions:
-#      - key: vendor
-#        operator: In
-#        values:
-#          - OpenShift
 #
 #  namespaces:
 #  - open-cluster-management

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -12,28 +12,26 @@ clusterGroup:
   - application-ci
 
   subscriptions:
-    acm:
-      name: advanced-cluster-management
+    - name: advanced-cluster-management
       namespace: open-cluster-management
       channel: release-2.4
       csv: advanced-cluster-management.v2.4.1
 
-    odh:
-      name: opendatahub-operator
+    - name: opendatahub-operator
+      channel: stable
       source: community-operators
       csv: opendatahub-operator.v1.1.0
       disabled: true
 
-    pipelines:
-      name: openshift-pipelines-operator-rh
+    - name: openshift-pipelines-operator-rh
+      channel: pipelines-1.8 
       csv: redhat-openshift-pipelines.v1.5.2
 
   projects:
   - datacenter
 
   applications:
-    acm:
-      name: acm
+    - name: acm
       namespace: open-cluster-management
       project: datacenter
       path: common/acm
@@ -42,15 +40,16 @@ clusterGroup:
         kind: ManagedClusterInfo
         jsonPointers:
         - /spec/loggingCA
-    pipe:
-      name: pipelines
+    
+    - name: pipelines
       namespace: application-ci
       project: datacenter
       path: charts/datacenter/pipelines
-    external:
-      name: external-app
+
+    - name: external-app
       namespace: demo
       project: datacenter
+      path: charts/datacenter/external-app
       clusterName: example
 
   managedClusterGroups:
@@ -64,8 +63,8 @@ clusterGroup:
     - name: clusterGroup.isHubCluster
       value: "false"
     clusterSelector:
-#      matchLabels:
-#        clusterGroup: factory
+      matchLabels:
+        clusterGroup: factory
       matchExpressions:
       - key: vendor
         operator: In

--- a/examples/values-secret.yaml
+++ b/examples/values-secret.yaml
@@ -17,16 +17,25 @@ secrets:
   aws:
     s3Secret: test-secret
 
+  secretStore:
+   name: vault-backend
+   kind: ClusterSecretStore
+
   # The cluster_xxxx pattern is used for creating externalSecrets that
-  # will be used by ArgoCD to push manifests to other clusters.
+  # will be used by ArgoCD to detect other clusters.
   #
   # Create a service account with enough permissions and extract the token
   #
   # CLUSTER_TOKEN=$(oc describe secret -n default argocd-external-token | grep 'token:' | awk '{print$2}')
   # CLUSTER_CA=$(oc extract -n openshift-config cm/kube-root-ca.crt --to=- --keys=ca.crt | base64 | awk '{print}' ORS='')
   cluster_example:
+    name: example
     server: https://api.example.openshiftapps.com:6443
-    bearerToken: <bearer_token>
-
-files:
-  cluster_example_ca: /path/to/ca.file
+    config: |
+      {
+        \"bearerToken\": \"<bearer_token>\",
+        \"tlsClientConfig\": {
+          \"insecure\": false,
+          \"caData\": \"<base64 encoded CA>\"
+        }
+      }

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -59,7 +59,10 @@ spec:
         "OpenShift"
       ]
     }
-  ]
+  ],
+  "matchLabels": {
+    "clusterGroup": "factory"
+  }
 }
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -12,6 +12,16 @@ metadata:
   name: common-example
 spec: {}
 ---
+# Source: pattern-clustergroup/templates/namespaces.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: pattern
+    argocd.argoproj.io/managed-by: common-example
+  name: open-cluster-management
+spec:
+---
 # Source: pattern-clustergroup/templates/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
@@ -55,6 +65,100 @@ subjects:
   - kind: ServiceAccount
     name: example-gitops-argocd-dex-server
     namespace: common-example
+---
+# Source: pattern-clustergroup/templates/subscriptions.yaml
+---
+---
+# Source: pattern-clustergroup/templates/projects.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: hub
+  namespace: common-example
+spec:
+  description: "Pattern hub"
+  destinations:
+  - namespace: '*'
+    server: '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+  - '*'
+status: {}
+---
+# Source: pattern-clustergroup/templates/projects.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: config-demo
+  namespace: common-example
+spec:
+  description: "Pattern config-demo"
+  destinations:
+  - namespace: '*'
+    server: '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+  - '*'
+status: {}
+---
+# Source: pattern-clustergroup/templates/applications.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: acm
+  namespace: common-example
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  destination:
+    name: in-cluster
+    namespace: open-cluster-management
+  project: hub
+  source:
+    repoURL: 
+    targetRevision: 
+    path: common/acm
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+      - "/values-global.yaml"
+      - "/values-example.yaml"
+      # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
+      parameters:
+        - name: global.repoURL
+          value: $ARGOCD_APP_SOURCE_REPO_URL
+        - name: global.targetRevision
+          value: $ARGOCD_APP_SOURCE_TARGET_REVISION
+        - name: global.namespace
+          value: $ARGOCD_APP_NAMESPACE
+        - name: global.pattern
+          value: common
+        - name: global.hubClusterDomain
+          value: 
+        - name: global.localClusterDomain
+          value: 
+  ignoreDifferences: [
+  {
+    "group": "internal.open-cluster-management.io",
+    "jsonPointers": [
+      "/spec/loggingCA"
+    ],
+    "kind": "ManagedClusterInfo"
+  }
+]
+  syncPolicy:
+    automated: {}
+    #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
@@ -180,3 +284,27 @@ spec:
   href: 'https://example-gitops-server-common-example.'
   location: ApplicationMenu
   text: 'Example ArgoCD'
+---
+# Source: pattern-clustergroup/templates/operatorgroup.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: open-cluster-management-operator-group
+  namespace: open-cluster-management
+spec:
+  targetNamespaces:
+  - open-cluster-management
+---
+# Source: pattern-clustergroup/templates/subscriptions.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: advanced-cluster-management
+  namespace: open-cluster-management
+spec:
+  name: advanced-cluster-management
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  channel: release-2.5
+  installPlanApproval: Automatic
+  startingCSV: advanced-cluster-management.v2.5.0

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -58,26 +58,24 @@ data:
   values.yaml: |
     clusterGroup:
       applications:
-        acm:
-          ignoreDifferences:
-          - group: internal.open-cluster-management.io
-            jsonPointers:
-            - /spec/loggingCA
-            kind: ManagedClusterInfo
-          name: acm
-          namespace: open-cluster-management
-          path: common/acm
-          project: datacenter
-        external:
-          clusterName: example
-          name: external-app
-          namespace: demo
-          project: datacenter
-        pipe:
-          name: pipelines
-          namespace: application-ci
-          path: charts/datacenter/pipelines
-          project: datacenter
+      - ignoreDifferences:
+        - group: internal.open-cluster-management.io
+          jsonPointers:
+          - /spec/loggingCA
+          kind: ManagedClusterInfo
+        name: acm
+        namespace: open-cluster-management
+        path: common/acm
+        project: datacenter
+      - name: pipelines
+        namespace: application-ci
+        path: charts/datacenter/pipelines
+        project: datacenter
+      - clusterName: example
+        name: external-app
+        namespace: demo
+        path: charts/datacenter/external-app
+        project: datacenter
       externalClusters:
       - example
       imperative:
@@ -109,6 +107,8 @@ data:
             operator: In
             values:
             - OpenShift
+          matchLabels:
+            clusterGroup: factory
         helmOverrides:
         - name: clusterGroup.isHubCluster
           value: "false"
@@ -121,21 +121,18 @@ data:
       projects:
       - datacenter
       subscriptions:
-        acm:
-          channel: release-2.4
-          csv: advanced-cluster-management.v2.4.1
-          name: advanced-cluster-management
-          namespace: open-cluster-management
-        odh:
-          csv: opendatahub-operator.v1.1.0
-          disabled: true
-          name: opendatahub-operator
-          source: community-operators
-        pipelines:
-          csv: redhat-openshift-pipelines.v1.5.2
-          name: openshift-pipelines-operator-rh
-    files:
-      cluster_example_ca: /path/to/ca.file
+      - channel: release-2.4
+        csv: advanced-cluster-management.v2.4.1
+        name: advanced-cluster-management
+        namespace: open-cluster-management
+      - channel: stable
+        csv: opendatahub-operator.v1.1.0
+        disabled: true
+        name: opendatahub-operator
+        source: community-operators
+      - channel: pipelines-1.8
+        csv: redhat-openshift-pipelines.v1.5.2
+        name: openshift-pipelines-operator-rh
     global:
       git:
         account: hybrid-cloud-patterns
@@ -163,7 +160,15 @@ data:
       aws:
         s3Secret: test-secret
       cluster_example:
-        bearerToken: <bearer_token>
+        config: |
+          {
+            \"bearerToken\": \"<bearer_token>\",
+            \"tlsClientConfig\": {
+              \"insecure\": false,
+              \"caData\": \"<base64 encoded CA>\"
+            }
+          }
+        name: example
         server: https://api.example.openshiftapps.com:6443
       git:
         token: test-git-token
@@ -171,6 +176,9 @@ data:
       imageregistry:
         account: test-account
         token: test-quay-token
+      secretStore:
+        kind: ClusterSecretStore
+        name: vault-backend
     secretsBase:
       key: secret/data/hub
 ---
@@ -505,19 +513,19 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: external-app
+  name: pipelines
   namespace: mypattern-example
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
-    name: example
-    namespace: demo
+    name: in-cluster
+    namespace: application-ci
   project: datacenter
   source:
     repoURL: https://github.com/pattern-clone/mypattern
     targetRevision: 
-    path: 
+    path: charts/datacenter/pipelines
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
@@ -545,19 +553,19 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: pipelines
+  name: external-app
   namespace: mypattern-example
   finalizers:
   - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   destination:
-    name: in-cluster
-    namespace: application-ci
+    name: example
+    namespace: demo
   project: datacenter
   source:
     repoURL: https://github.com/pattern-clone/mypattern
     targetRevision: 
-    path: charts/datacenter/pipelines
+    path: charts/datacenter/external-app
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
@@ -797,6 +805,6 @@ spec:
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  channel: stable
+  channel: pipelines-1.8
   installPlanApproval: Automatic
   startingCSV: redhat-openshift-pipelines.v1.5.2


### PR DESCRIPTION
Having a schema for some of our values files will get us:
 - Minimize mistakes in the values files.
 - If there are mistakes we can discover them before deploying a validated pattern.
 - Having a pre-deploy target might be useful to validate the values files and give
   the user to continue or abort the deployment of the pattern.
 - Enforce structure in key values files used by the validated patterns framework.

The schema for the clustergroup chart will apply to any values-*.yaml file since it
is the main chart for the Validated Patterns framework.  The schema includes our
global and main schemas to enable helm to validate these sections that we use in the
values-global.yaml file.

We think that this is a good solution to ensure that users do not add extraneous
properties to the values files and it will, hopefully, help us with our documentation
of the properties required in each of the values files for Validated Patterns.
