### PR TITLE
Rewrite push_secrets as an ansible python plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+__pycache__/
+*.py[cod]
 *~
 *.swp
 *.swo
@@ -7,3 +9,4 @@ pattern-vault.init
 pattern-vault.init.bak
 super-linter.log
 golang-external-secrets/Chart.lock
+hashicorp-vault/Chart.lock

--- a/Makefile
+++ b/Makefile
@@ -98,5 +98,8 @@ super-linter: ## Runs super linter locally
 ansible-lint: ## run ansible lint on ansible/ folder
 	podman run -it -v $(PWD):/workspace:rw,z --workdir /workspace --entrypoint "/usr/local/bin/ansible-lint" quay.io/ansible/creator-ee:latest  "-vvv" "ansible/"
 
+ansible-unittest: ## run ansible unit tests
+	pytest -r a --fulltrace --color yes ansible/tests/unit/test_*.py
+
 .phony: install test
 

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
 display_skipped_hosts=False
 localhost_warning=False
+library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -1,0 +1,349 @@
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Ansible plugin module that loads secrets from a yaml file and pushes them
+inside the HashiCorp Vault in an OCP cluster. The values-secrets.yaml file is
+expected to be in the following format:
+---
+# version is optional. When not specified it is assumed it is 1.0
+version: 1.0
+
+# These secrets will be pushed in the vault at secret/hub/test The vault will
+# have secret/hub/test with secret1 and secret2 as keys with their associated
+# values (secrets)
+secrets:
+  test:
+    secret1: foo
+    secret2: bar
+
+# This will create the vault key secret/hub/testfoo which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
+files:
+  testfoo: ~/ca.crt
+
+# These secrets will be pushed in the vault at secret/region1/test The vault will
+# have secret/region1/test with secret1 and secret2 as keys with their associated
+# values (secrets)
+secrets.region1:
+  test:
+    secret1: foo1
+    secret2: bar1
+
+# This will create the vault key secret/region2/testbar which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
+files.region2:
+  testbar: ~/ca.crt
+"""
+
+import base64
+import os
+import subprocess
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: vault_load_secrets
+short_description: Loads secrets into the HashiCorp Vault
+version_added: "2.11"
+author: "Michele Baldessari"
+description:
+  - Takes a values-secret.yaml file and uploads the secrets into the HashiCorp Vault
+options:
+  values_secrets:
+    description:
+      - Path to the values-secrets file
+    required: true
+    type: str
+  namespace:
+    description:
+      - Namespace where the vault is running
+    required: false
+    type: str
+    default: vault
+  pod:
+    description:
+      - Name of the vault pod to use to inject secrets
+    required: false
+    type: str
+    default: vault-0
+  basepath:
+    description:
+      - Vault's kv initial part of the path
+    required: false
+    type: str
+    default: secret
+'''
+
+RETURN = '''
+'''
+
+EXAMPLES = '''
+- name: Loads secrets file into the vault of a cluster
+  vault_load_secrets:
+    values_secrets: ~/values-secret.yaml
+'''
+
+def parse_values(values_file):
+    '''
+    Parses a values-secrets.yaml file (usually placed in ~)
+    and returns a Python Obect with the parsed yaml.
+
+    Parameters:
+        values_file(str): The path of the values-secrets.yaml file
+        to be parsed.
+
+    Returns:
+        secrets_yaml(obj): The python object containing the parsed yaml
+    '''
+    with open(values_file, 'r', encoding='utf-8') as file:
+        secrets_yaml = yaml.safe_load(file.read())
+    return secrets_yaml
+
+def get_version(syaml):
+    '''
+    Return the version: of the parsed yaml object. If it does not exist
+    return 1.0
+
+    Returns:
+        ret(str): The version value in of the top-level 'version:' key
+    '''
+    return syaml.get('version', '1.0')
+
+def run_command(command):
+    '''
+    Runs a command on the host ansible is running on. A failing command
+    will raise an exception in this function directly (due to check=True)
+
+    Parameters:
+        command(str): The command to be run.
+
+    Returns:
+        ret(subprocess.CompletedProcess): The return value from run()
+    '''
+    ret = subprocess.run(command, shell=True, env=os.environ.copy(),
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                        universal_newlines=True, check=True)
+    return ret
+
+def sanitize_values(module, syaml):
+    '''
+    Sanitizes the secrets YAML object. If a specific secret key has
+    s3.accessKey and s3.secretKey but not s3Secret, the latter will be
+    generated as the base64 encoding of both s3.accessKey and s3.secretKey.
+
+      secrets:
+        test:
+          s3.accessKey: "1234"
+          s3.secretKey: "4321"
+
+    will push three secrets at 'secret/hub/test':
+
+    s3.accessKey: 1234
+    s3.secretKey: 4321
+    s3Secret: czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ==
+
+    Parameters:
+        module(AnsibleModule): The current AnsibleModule being used
+
+        syaml(obj): The parsed yaml object representing the secrets
+
+    Returns:
+        syaml(obj): The parsed yaml object sanitized
+    '''
+    if not ('secrets' in syaml or 'files' in syaml):
+        module.fail_json(f"Values secrets file does not contain 'secrets' or" \
+                         f"'files' keys: {syaml}")
+
+    secrets = syaml.get('secrets', {})
+    files = syaml.get('files', {})
+    if len(secrets) == 0 and len(files) == 0:
+        module.fail_json(f"Neither 'secrets' nor 'files have any secrets to " \
+                         f"be parsed: {syaml}")
+
+    for secret in secrets:
+        if not isinstance(secrets[secret], dict):
+            module.fail_json(f"Each key under 'secrets' needs to point to " \
+                             f"a dictionary of key value pairs: {syaml}")
+
+    for file in files:
+        path = files[file]
+        if not os.path.isfile(path):
+            module.fail_json(f"File {path} does not exist")
+
+    # If s3Secret key does not exist but s3.accessKey and s3.secretKey do exist
+    # generate s3Secret so a user does not need to do it manually which tends to be error-prone
+    for secret in secrets:
+        tmp = secrets[secret]
+        if 's3.accessKey' in tmp and 's3.secretKey' in tmp and 's3Secret' not in tmp:
+            s3secret = (f"s3.accessKey: {tmp['s3.accessKey']}\n"
+                        f"s3.secretKey: {tmp['s3.secretKey']}")
+            s3secretb64 = base64.b64encode(s3secret.encode())
+            secrets[secret]['s3Secret'] = s3secretb64.decode("utf-8")
+
+    return syaml
+
+def get_secrets_vault_paths(module, syaml, keyname):
+    '''
+    Walks a secrets yaml object to look for all top-level keys that start with
+    'keyname' and returns a list of tuples [(keyname1, path1), (keyname2, path2)...]
+    where the path is the relative vault path
+    For example, given a yaml with the following:
+        secrets:
+            foo: bar
+        secrets.region1:
+            foo: baz
+        secrets.region2:
+            foo: barbaz
+
+    a call with keyname set to 'secrets' will return the following:
+    [('secrets', 'hub'), ('secrets', 'region1'), ('secrets', 'region2')]
+
+    Parameters:
+        module(AnsibleModule): The current AnsibleModule being used
+
+        syaml(obj): The parsed yaml object representing the secrets
+
+        keyname(str): The keytypes to look for either usually 'secrets' or 'files'
+
+    Returns:
+        keys_paths(list): List of tuples containing (keyname, relative-vault-path)
+    '''
+    all_keys = syaml.keys()
+    keys_paths = []
+    for key in all_keys:
+        # We skip any key that does not start with 'secrets' or 'files'
+        # (We should probably bail out in the presence of unexpected top-level keys)
+        if not key.startswith(keyname):
+            continue
+
+        # If there is no '.' after secrets or files, assume the secrets need to
+        # go to the hub vault path
+        if key == keyname:
+            keys_paths.append((key, 'hub'))
+            continue
+
+        # We are in the presence of either 'secrets.region-one' or 'files.cluster1' top-level keys
+        tmp = key.split('.')
+        if len(tmp) != 2:
+            module.fail_json(f"values-secrets.yaml key is non-conformant: {key}")
+
+        keys_paths.append((key, tmp[1]))
+
+    return keys_paths
+
+# NOTE(bandini): we shell out to oc exec it because of https://github.com/ansible-collections/kubernetes.core/issues/506
+# and https://github.com/kubernetes/kubernetes/issues/89899. Until those are solved it makes little sense
+# to invoke the APIs via the python wrappers
+def inject_secrets(module, syaml, namespace, pod, basepath):
+    '''
+    Walks a secrets yaml object and injects all the secrets into the vault via 'oc exec' calls
+
+    Parameters:
+        module(AnsibleModule): The current AnsibleModule being used
+
+        syaml(obj): The parsed yaml object representing the secrets
+
+        namespace(str): The namespace in which the vault is
+
+        pod(str): The pod name where the vault is
+
+        basepath(str): The base string to which we concatenate the vault
+        relative paths
+
+    Returns:
+        counter(int): The number of secrets injected
+    '''
+    counter = 0
+    for i in get_secrets_vault_paths(module, syaml, 'secrets'):
+        path = f"{basepath}/{i[1]}"
+        for secret in syaml[i[0]]:
+            properties = ''
+            for key, value in syaml[i[0]][secret].items():
+                properties += f"{key}='{value}' "
+            properties = properties.rstrip()
+            cmd = (f"oc exec -n {namespace} {pod} -i -- sh -c "
+                   f"\"vault kv put '{path}/{secret}' {properties}\"")
+            run_command(cmd)
+            counter += 1
+
+    for i in get_secrets_vault_paths(module, syaml, 'files'):
+        path = f"{basepath}/{i[1]}"
+        for filekey in syaml[i[0]]:
+            file = os.path.expanduser(syaml[i[0]][filekey])
+            cmd = (f"cat '{file}' | oc exec -n {namespace} {pod} -i -- sh -c "
+                   f"'cat - > /tmp/vcontent'; "
+                   f"oc exec -n {namespace} {pod} -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | "
+                   f"vault kv put {path}/{filekey} b64content=- content=@/tmp/vcontent; "
+                   f"rm /tmp/vcontent'"
+                  )
+            run_command(cmd)
+            counter += 1
+    return counter
+
+def run(module):
+    '''Main ansible module entry point'''
+    results = dict(
+        changed=False
+    )
+
+    args = module.params
+    values_secrets = os.path.expanduser(args.get('values_secrets'))
+    basepath = args.get('basepath')
+    namespace = args.get('namespace')
+    pod = args.get('pod')
+
+    if not os.path.exists(values_secrets):
+        results['failed'] = True
+        results['error'] = "Missing values-secrets.yaml file"
+        results['msg'] = f"Values secrets file does not exist: {values_secrets}"
+        module.exit_json(**results)
+
+    syaml = parse_values(values_secrets)
+    version = get_version(syaml)
+
+    if version != '1.0':
+        module.fail_json(f"Version {version} is currently not supported")
+
+    # In the future we can use the version field to manage different formats if needed
+    secrets = sanitize_values(module, syaml)
+    nr_secrets = inject_secrets(module, secrets, namespace, pod, basepath)
+    results['failed'] = False
+    results['changed'] = True
+    results['msg'] = f"{nr_secrets} secrets injected"
+    module.exit_json(**results)
+
+
+def main():
+    '''Main entry point where the AnsibleModule class is instantiated'''
+    module = AnsibleModule(
+        argument_spec=yaml.safe_load(DOCUMENTATION)['options'],
+        supports_check_mode=False,
+    )
+    run(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -178,18 +178,18 @@ def sanitize_values(module, syaml):
         syaml(obj): The parsed yaml object sanitized
     '''
     if not ('secrets' in syaml or 'files' in syaml):
-        module.fail_json(f"Values secrets file does not contain 'secrets' or" \
+        module.fail_json(f"Values secrets file does not contain 'secrets' or"
                          f"'files' keys: {syaml}")
 
     secrets = syaml.get('secrets', {})
     files = syaml.get('files', {})
     if len(secrets) == 0 and len(files) == 0:
-        module.fail_json(f"Neither 'secrets' nor 'files have any secrets to " \
+        module.fail_json(f"Neither 'secrets' nor 'files have any secrets to "
                          f"be parsed: {syaml}")
 
     for secret in secrets:
         if not isinstance(secrets[secret], dict):
-            module.fail_json(f"Each key under 'secrets' needs to point to " \
+            module.fail_json(f"Each key under 'secrets' needs to point to "
                              f"a dictionary of key value pairs: {syaml}")
 
     for file in files:
@@ -259,6 +259,7 @@ def get_secrets_vault_paths(module, syaml, keyname):
 
     return keys_paths
 
+
 # NOTE(bandini): we shell out to oc exec it because of
 # https://github.com/ansible-collections/kubernetes.core/issues/506 and
 # https://github.com/kubernetes/kubernetes/issues/89899. Until those are solved
@@ -303,11 +304,11 @@ def inject_secrets(module, syaml, namespace, pod, basepath):
                    f"'cat - > /tmp/vcontent'; "
                    f"oc exec -n {namespace} {pod} -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | "
                    f"vault kv put {path}/{filekey} b64content=- content=@/tmp/vcontent; "
-                   f"rm /tmp/vcontent'"
-                  )
+                   f"rm /tmp/vcontent'")
             run_command(cmd)
             counter += 1
     return counter
+
 
 def run(module):
     '''Main ansible module entry point'''

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -106,6 +106,7 @@ EXAMPLES = '''
     values_secrets: ~/values-secret.yaml
 '''
 
+
 def parse_values(values_file):
     '''
     Parses a values-secrets.yaml file (usually placed in ~)
@@ -122,6 +123,7 @@ def parse_values(values_file):
         secrets_yaml = yaml.safe_load(file.read())
     return secrets_yaml
 
+
 def get_version(syaml):
     '''
     Return the version: of the parsed yaml object. If it does not exist
@@ -131,6 +133,7 @@ def get_version(syaml):
         ret(str): The version value in of the top-level 'version:' key
     '''
     return syaml.get('version', '1.0')
+
 
 def run_command(command):
     '''
@@ -144,9 +147,10 @@ def run_command(command):
         ret(subprocess.CompletedProcess): The return value from run()
     '''
     ret = subprocess.run(command, shell=True, env=os.environ.copy(),
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                        universal_newlines=True, check=True)
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         universal_newlines=True, check=True)
     return ret
+
 
 def sanitize_values(module, syaml):
     '''
@@ -205,6 +209,7 @@ def sanitize_values(module, syaml):
 
     return syaml
 
+
 def get_secrets_vault_paths(module, syaml, keyname):
     '''
     Walks a secrets yaml object to look for all top-level keys that start with
@@ -254,9 +259,10 @@ def get_secrets_vault_paths(module, syaml, keyname):
 
     return keys_paths
 
-# NOTE(bandini): we shell out to oc exec it because of https://github.com/ansible-collections/kubernetes.core/issues/506
-# and https://github.com/kubernetes/kubernetes/issues/89899. Until those are solved it makes little sense
-# to invoke the APIs via the python wrappers
+# NOTE(bandini): we shell out to oc exec it because of
+# https://github.com/ansible-collections/kubernetes.core/issues/506 and
+# https://github.com/kubernetes/kubernetes/issues/89899. Until those are solved
+# it makes little sense to invoke the APIs via the python wrappers
 def inject_secrets(module, syaml, namespace, pod, basepath):
     '''
     Walks a secrets yaml object and injects all the secrets into the vault via 'oc exec' calls

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -53,8 +53,8 @@ files.region2:
 import base64
 import os
 import subprocess
-import yaml
 
+import yaml
 from ansible.module_utils.basic import AnsibleModule
 
 ANSIBLE_METADATA = {

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -2,6 +2,7 @@
 - include_tasks: pre_check.yaml
 - include_tasks: vault_status.yaml
 
+
 # Unfortunately we cannot loop vault_status and just check if the vault is unsealed
 # https://github.com/ansible/proposals/issues/136
 # So here we keep running the 'vault status' command until sealed is set to false
@@ -15,158 +16,6 @@
   retries: 20
   delay: 45
   failed_when: "'stdout_lines' not in vault_status_json"
-
-- name: Check for existence of "{{ values_secret }}"
-  ansible.builtin.stat:
-    path: "{{ values_secret }}"
-  register: result
-  failed_when: not result.stat.exists
-
-- name: Parse "{{ values_secret }}"
-  ansible.builtin.set_fact:
-    all_values: "{{ lookup('file', values_secret) | from_yaml | default({}, true) }}"
-
-- name: Check for secrets keys
-  ansible.builtin.assert:
-    that:
-      - "('secrets' in all_values.keys()) or ('files' in all_values.keys())"
-    fail_msg: "Was not able to parse any secrets from file {{ values_secret }}. Either 'secrets:' or 'files:' top-level keys (or both) must exist"
-
-- name: Set secrets and file_secrets facts
-  ansible.builtin.set_fact:
-    secrets: "{{ all_values['secrets'] | default({}) }}"
-    file_secrets: "{{ all_values['files'] | default({}) }}"
-
-- name: Verify we have any secrets at all
-  ansible.builtin.fail:
-    msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
-  failed_when:
-    secrets | combine(file_secrets) | length == 0
-
-- name: Check the value-secret.yaml file for errors in the secrets section
-  ansible.builtin.fail:
-    msg: >
-      "{{ item }}" is not properly formatted. Each key under 'secrets:'
-      needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
-  when: >
-    item.key | length == 0 or
-    item.value is not mapping
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-- name: Validate file references in the files section of value-secret.yaml
-  ansible.builtin.stat:
-    path: '{{ file_stat.value }}'
-  register: file_values
-  loop_control:
-    loop_var: file_stat
-  loop:
-    "{{ file_secrets | dict2items }}"
-
-- name: Debug file_stat
-  ansible.builtin.debug:
-    var: file_stat
-  when: debug | default(False) | bool
-
-- name: Debug file_values
-  ansible.builtin.debug:
-    var: file_values
-  when: debug | default(False) | bool
-
-- name: Fail if referenced file does not exist
-  ansible.builtin.fail:
-    msg: >
-      "file {{ item.file_stat.key }} {{ item.file_stat.value }}" must exist and be a file
-  when: >
-    not item.stat.exists
-  loop:
-    "{{ file_values.results }}"
-
-# Detect here if we have only the following two keys under a password
-# s3.accessKey: <accessKey>
-# s3.secretKey: <secret key>
-# If we do, then detect it and calculate the b64 s3Secret token
-# Note: the vars: line is due to https://github.com/ansible/ansible/issues/40239
-- name: Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case
-  ansible.builtin.set_fact:
-    s3keys: "{{ s3keys | default({}) | combine({ item.key: {'s3Secret': s3secret | b64encode } }) }}"
-  vars:
-    s3secret: "{{ 's3.accessKey: ' + item.value['s3.accessKey'] + '\ns3.secretKey: ' + item.value['s3.secretKey'] }}"
-  when:
-    - '"s3.accessKey" in item.value.keys()'
-    - '"s3.secretKey" in item.value.keys()'
-    - '"s3Secret" not in item.value.keys()'
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-- name: Merge any s3Secret into the secrets dictionary if we have any
-  ansible.builtin.set_fact:
-    secrets: "{{ secrets | combine(s3keys) }}"
-  when:
-    s3keys is defined and s3keys | length > 0
-
-# The values-secret.yaml file is in the fairly loose form of:
-# secrets:
-#   group1:
-#     key1: value1
-#     key2: value2
-#   group2:
-#     key1: valueA
-#     key4: valueC
-# The above will generate:
-# vault kv put 'secret/hub/group1' key1='value1' key2='value2'
-# vault kv put 'secret/hub/group2' key1='valueA' key4='valueC'
-# Below we loop on the top level keys (group1, group2) and for each
-# sub-top-level key (key1, key2) we create a single 'key1=value1 key2=value2' string
-#
-# Special note is to be given to the regex_replace which is run against each value aka password:
-# A. The need for it is to quote the passwords
-# B. Since it needs to cater to multiline strings (certs) and ansible offers no way
-#    to specify re.DOTALL and re.MULTILINE we need to use (?ms) at the beginning
-#    See https://docs.python.org/3/library/re.html and (?aiLmsux) section
-#    and https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py#L124
-# C. The \\A and \\Z match the beginning and end of a string (in case of multiline strings
-#    do not want to match every line)
-
-- name: Set defaults for vault_cmds and secret_files_vault_cmds to prevent undefined variable errors
-  ansible.builtin.set_fact:
-    vault_cmds: "{{ vault_cmds | default({}) }}"
-    secret_files_vault_cmds: "{{ secret_files_vault_cmds | default({}) }}"
-
-- name: Set secrets vault commands fact
-  ansible.builtin.set_fact:
-    vault_cmds: "{{ vault_cmds | combine({ item.key: vault_cmd}) }}"
-  vars:
-    vault_cmd: "vault kv put '{{ vault_path }}/{{ item.key }}'
-      {{ item.value.keys() | zip(item.value.values() | map('regex_replace', '(?ms)\\A(.*)\\Z', \"'\\1'\")) | map('join', '=') | list | join(' ') }}"
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-- name: Set files vault commands fact
-  ansible.builtin.set_fact:
-    secret_files_vault_cmds: "{{ secret_files_vault_cmds | combine({ item.key: vault_cmd}) }}"
-  vars:
-    vault_cmd: "cat '{{ item.value | expanduser }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'cat - > /tmp/vault_content'; oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'base64 --wrap=0 /tmp/vault_content | vault kv put {{ vault_path }}/{{ item.key }} b64content=- content=@/tmp/vault_content; rm /tmp/vault_content'" # noqa yaml
-  loop:
-    "{{ file_secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-- name: Debug vault commands
-  ansible.builtin.debug:
-    msg: "{{ vault_cmds }}"
-  when: debug | default(False) | bool
-
-- name: Debug files vault commands
-  ansible.builtin.debug:
-    msg: "{{ secret_files_vault_cmds }}"
-  when: debug | default(False) | bool
 
 # This step is not really needed when running make vault-init + load-secrets as
 # everything is sequential
@@ -185,24 +34,6 @@
   delay: 45
   changed_when: false
 
-- name: Add the actual secrets to the vault
-  kubernetes.core.k8s_exec:
-    namespace: "{{ vault_ns }}"
-    pod: "{{ vault_pod }}"
-    command: |
-      sh -c "{{ item.value }}"
-  loop:
-    "{{ vault_cmds | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when: not debug | default(False) | bool
-
-  # This has to be shell because of the use of stdin and pipes
-- name: Add the file secrets to the vault
-  ansible.builtin.shell: # noqa: command-instead-of-shell
-    "{{ item.value }}"
-  loop:
-    "{{ secret_files_vault_cmds | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when: not debug | default(False) | bool
+- name: Loads secrets file into the vault of a cluster
+  vault_load_secrets:
+    values_secrets: ~/values-secret.yaml

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -38,11 +38,13 @@ def set_module_args(args):
 
 class AnsibleExitJson(Exception):
     """Exception class to be raised by module.exit_json and caught by the test case"""
+
     pass
 
 
 class AnsibleFailJson(Exception):
     """Exception class to be raised by module.fail_json and caught by the test case"""
+
     pass
 
 
@@ -61,9 +63,9 @@ def fail_json(*args, **kwargs):
 
 class TestMyModule(unittest.TestCase):
     def setUp(self):
-        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
-                                                 exit_json=exit_json,
-                                                 fail_json=fail_json)
+        self.mock_module_helper = patch.multiple(
+            basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+        )
         self.mock_module_helper.start()
         self.addCleanup(self.mock_module_helper.stop)
 
@@ -74,21 +76,28 @@ class TestMyModule(unittest.TestCase):
 
     def test_module_fail_when_values_secret_not_existing(self):
         with self.assertRaises(AnsibleExitJson) as ansible_err:
-            set_module_args({
-                'values_secrets': "/tmp/nonexisting",
-            })
+            set_module_args(
+                {
+                    'values_secrets': "/tmp/nonexisting",
+                }
+            )
             vault_load_secrets.main()
 
         ret = ansible_err.exception.args[0]
         self.assertEqual(ret['failed'], True)
         self.assertEqual(ret['error'], 'Missing values-secrets.yaml file')
-        self.assertEqual(ret['msg'], 'Values secrets file does not exist: /tmp/nonexisting')
+        self.assertEqual(
+            ret['msg'], 'Values secrets file does not exist: /tmp/nonexisting'
+        )
 
     def test_ensure_command_called(self):
-        set_module_args({
-            'values_secrets': os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                           'values-secret.yaml')
-        })
+        set_module_args(
+            {
+                'values_secrets': os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), 'values-secret.yaml'
+                )
+            }
+        )
 
         with patch.object(vault_load_secrets, 'run_command') as mock_run_command:
             stdout = 'configuration updated'
@@ -98,19 +107,39 @@ class TestMyModule(unittest.TestCase):
 
             with self.assertRaises(AnsibleExitJson) as result:
                 vault_load_secrets.main()
-            self.assertTrue(result.exception.args[0]['changed'])  # ensure result is changed
+            self.assertTrue(
+                result.exception.args[0]['changed']
+            )  # ensure result is changed
             assert mock_run_command.call_count == 9
 
         calls = [
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/config-demo\' secret=\'demo123\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/googleapi\' key=\'lskdjflskjdflsdjflsdkjfldsjkfldsj\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/cluster_alejandro\' name=\'alejandro\' bearerToken=\'sha256~bumxi-012345678901233455675678678098-abcdef\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test\' s3.accessKey=\'1234\' s3.secretKey=\'4321\' s3Secret=\'czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ==\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test2\' s3.accessKey=\'accessKey\' s3.secretKey=\'secretKey\' s3Secret=\'fooo\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test3\' s3.accessKey=\'aaaaa\' s3.secretKey=\'bbbbbbbb\' s3Secret=\'czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi\'"'),
-            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/region-one/config-demo\' secret=\'region123\'"'),
-            call("cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"),
-            call("cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'")
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/config-demo\' secret=\'demo123\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/googleapi\' key=\'lskdjflskjdflsdjflsdkjfldsjkfldsj\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/cluster_alejandro\' name=\'alejandro\' bearerToken=\'sha256~bumxi-012345678901233455675678678098-abcdef\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test\' s3.accessKey=\'1234\' s3.secretKey=\'4321\' s3Secret=\'czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ==\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test2\' s3.accessKey=\'accessKey\' s3.secretKey=\'secretKey\' s3Secret=\'fooo\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test3\' s3.accessKey=\'aaaaa\' s3.secretKey=\'bbbbbbbb\' s3Secret=\'czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi\'"'
+            ),
+            call(
+                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/region-one/config-demo\' secret=\'region123\'"'
+            ),
+            call(
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"
+            ),
+            call(
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"
+            ),
         ]
         mock_run_command.assert_has_calls(calls)
 

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(1, './ansible/ansible_plugins/modules')
+sys.path.insert(1, './ansible/plugins/modules')
 from unittest.mock import patch, call
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -1,0 +1,109 @@
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(1, './ansible/ansible_plugins/modules')
+from unittest.mock import patch, call
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+import vault_load_secrets
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation"""
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the test case"""
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the test case"""
+    pass
+
+
+def exit_json(*args, **kwargs):
+    """function to patch over exit_json; package return data into an exception"""
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an exception"""
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def get_bin_path(self, arg, required=False):
+    """Mock AnsibleModule.get_bin_path"""
+    if arg.endswith('my_command'):
+        return '/usr/bin/my_command'
+    else:
+        if required:
+            fail_json(msg='%r not found !' % arg)
+
+
+class TestMyModule(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json,
+                                                 get_bin_path=get_bin_path)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+    def test_module_fail_when_required_args_missing(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            vault_load_secrets.main()
+
+    def test_module_fail_when_values_secret_not_existing(self):
+        with self.assertRaises(AnsibleExitJson) as ansible_err:
+            set_module_args({
+                'values_secrets': "/tmp/nonexisting",
+            })
+            vault_load_secrets.main()
+
+        ret = ansible_err.exception.args[0]
+        self.assertEqual(ret['failed'], True)
+        self.assertEqual(ret['error'], 'Missing values-secrets.yaml file')
+        self.assertEqual(ret['msg'], 'Values secrets file does not exist: /tmp/nonexisting')
+
+    def test_ensure_command_called(self):
+        set_module_args({
+            'values_secrets': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'values-secret.yaml')
+        })
+
+        with patch.object(vault_load_secrets, 'run_command') as mock_run_command:
+            stdout = 'configuration updated'
+            stderr = ''
+            rc = 0
+            mock_run_command.return_value = rc, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                vault_load_secrets.main()
+            self.assertTrue(result.exception.args[0]['changed']) # ensure result is changed
+            assert mock_run_command.call_count == 9
+
+        calls = [
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/config-demo\' secret=\'demo123\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/googleapi\' key=\'lskdjflskjdflsdjflsdkjfldsjkfldsj\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/cluster_alejandro\' name=\'alejandro\' bearerToken=\'sha256~bumxi-012345678901233455675678678098-abcdef\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test\' s3.accessKey=\'1234\' s3.secretKey=\'4321\' s3Secret=\'czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ==\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test2\' s3.accessKey=\'accessKey\' s3.secretKey=\'secretKey\' s3Secret=\'fooo\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test3\' s3.accessKey=\'aaaaa\' s3.secretKey=\'bbbbbbbb\' s3Secret=\'czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi\'"'),
+            call('oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/region-one/config-demo\' secret=\'region123\'"'),
+            call("cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"),
+            call("cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'")
+        ]
+        mock_run_command.assert_has_calls(calls)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -21,8 +21,8 @@ import json
 import os
 import sys
 import unittest
+from unittest.mock import call, patch
 
-from unittest.mock import patch, call
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
@@ -98,7 +98,7 @@ class TestMyModule(unittest.TestCase):
 
             with self.assertRaises(AnsibleExitJson) as result:
                 vault_load_secrets.main()
-            self.assertTrue(result.exception.args[0]['changed']) # ensure result is changed
+            self.assertTrue(result.exception.args[0]['changed'])  # ensure result is changed
             assert mock_run_command.call_count == 9
 
         calls = [
@@ -113,6 +113,7 @@ class TestMyModule(unittest.TestCase):
             call("cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'")
         ]
         mock_run_command.assert_has_calls(calls)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -27,7 +27,7 @@ from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
 sys.path.insert(1, "./ansible/plugins/modules")
-import vault_load_secrets
+import vault_load_secrets  # noqa: E402
 
 
 def set_module_args(args):
@@ -114,31 +114,31 @@ class TestMyModule(unittest.TestCase):
 
         calls = [
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='demo123'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='demo123'\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/googleapi' key='lskdjflskjdflsdjflsdkjfldsjkfldsj'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/googleapi' key='lskdjflskjdflsdjflsdkjfldsjkfldsj'\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/cluster_alejandro' name='alejandro' bearerToken='sha256~bumxi-012345678901233455675678678098-abcdef'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/cluster_alejandro' name='alejandro' bearerToken='sha256~bumxi-012345678901233455675678678098-abcdef'\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test' s3.accessKey='1234' s3.secretKey='4321' s3Secret='czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ=='\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test' s3.accessKey='1234' s3.secretKey='4321' s3Secret='czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ=='\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test2' s3.accessKey='accessKey' s3.secretKey='secretKey' s3Secret='fooo'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test2' s3.accessKey='accessKey' s3.secretKey='secretKey' s3Secret='fooo'\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test3' s3.accessKey='aaaaa' s3.secretKey='bbbbbbbb' s3Secret='czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test3' s3.accessKey='aaaaa' s3.secretKey='bbbbbbbb' s3Secret='czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi'\""  # noqa: E501
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/region-one/config-demo' secret='region123'\""
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/region-one/config-demo' secret='region123'\""  # noqa: E501
             ),
             call(
-                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
             ),
             call(
-                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
             ),
         ]
         mock_run_command.assert_has_calls(calls)

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -26,13 +26,13 @@ from unittest.mock import call, patch
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
-sys.path.insert(1, './ansible/plugins/modules')
+sys.path.insert(1, "./ansible/plugins/modules")
 import vault_load_secrets
 
 
 def set_module_args(args):
     """prepare arguments so that they will be picked up during module creation"""
-    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    args = json.dumps({"ANSIBLE_MODULE_ARGS": args})
     basic._ANSIBLE_ARGS = to_bytes(args)
 
 
@@ -50,14 +50,14 @@ class AnsibleFailJson(Exception):
 
 def exit_json(*args, **kwargs):
     """function to patch over exit_json; package return data into an exception"""
-    if 'changed' not in kwargs:
-        kwargs['changed'] = False
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
     raise AnsibleExitJson(kwargs)
 
 
 def fail_json(*args, **kwargs):
     """function to patch over fail_json; package return data into an exception"""
-    kwargs['failed'] = True
+    kwargs["failed"] = True
     raise AnsibleFailJson(kwargs)
 
 
@@ -78,61 +78,61 @@ class TestMyModule(unittest.TestCase):
         with self.assertRaises(AnsibleExitJson) as ansible_err:
             set_module_args(
                 {
-                    'values_secrets': "/tmp/nonexisting",
+                    "values_secrets": "/tmp/nonexisting",
                 }
             )
             vault_load_secrets.main()
 
         ret = ansible_err.exception.args[0]
-        self.assertEqual(ret['failed'], True)
-        self.assertEqual(ret['error'], 'Missing values-secrets.yaml file')
+        self.assertEqual(ret["failed"], True)
+        self.assertEqual(ret["error"], "Missing values-secrets.yaml file")
         self.assertEqual(
-            ret['msg'], 'Values secrets file does not exist: /tmp/nonexisting'
+            ret["msg"], "Values secrets file does not exist: /tmp/nonexisting"
         )
 
     def test_ensure_command_called(self):
         set_module_args(
             {
-                'values_secrets': os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), 'values-secret.yaml'
+                "values_secrets": os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "values-secret.yaml"
                 )
             }
         )
 
-        with patch.object(vault_load_secrets, 'run_command') as mock_run_command:
-            stdout = 'configuration updated'
-            stderr = ''
+        with patch.object(vault_load_secrets, "run_command") as mock_run_command:
+            stdout = "configuration updated"
+            stderr = ""
             ret = 0
             mock_run_command.return_value = ret, stdout, stderr  # successful execution
 
             with self.assertRaises(AnsibleExitJson) as result:
                 vault_load_secrets.main()
             self.assertTrue(
-                result.exception.args[0]['changed']
+                result.exception.args[0]["changed"]
             )  # ensure result is changed
             assert mock_run_command.call_count == 9
 
         calls = [
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/config-demo\' secret=\'demo123\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='demo123'\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/googleapi\' key=\'lskdjflskjdflsdjflsdkjfldsjkfldsj\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/googleapi' key='lskdjflskjdflsdjflsdkjfldsjkfldsj'\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/cluster_alejandro\' name=\'alejandro\' bearerToken=\'sha256~bumxi-012345678901233455675678678098-abcdef\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/cluster_alejandro' name='alejandro' bearerToken='sha256~bumxi-012345678901233455675678678098-abcdef'\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test\' s3.accessKey=\'1234\' s3.secretKey=\'4321\' s3Secret=\'czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ==\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test' s3.accessKey='1234' s3.secretKey='4321' s3Secret='czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ=='\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test2\' s3.accessKey=\'accessKey\' s3.secretKey=\'secretKey\' s3Secret=\'fooo\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test2' s3.accessKey='accessKey' s3.secretKey='secretKey' s3Secret='fooo'\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/hub/test3\' s3.accessKey=\'aaaaa\' s3.secretKey=\'bbbbbbbb\' s3Secret=\'czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test3' s3.accessKey='aaaaa' s3.secretKey='bbbbbbbb' s3Secret='czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi'\""
             ),
             call(
-                'oc exec -n vault vault-0 -i -- sh -c "vault kv put \'secret/region-one/config-demo\' secret=\'region123\'"'
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/region-one/config-demo' secret='region123'\""
             ),
             call(
                 "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"
@@ -144,5 +144,5 @@ class TestMyModule(unittest.TestCase):
         mock_run_command.assert_has_calls(calls)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/examples/values-secret.yaml
+++ b/examples/values-secret.yaml
@@ -1,7 +1,9 @@
-main:
-  git:
-    repoURL: https://github.com/example/common
+# version is optional. When not specified it is assumed it is 1.0
+version: 1.0
 
+# These secrets will be pushed in the vault at secret/hub/test The vault will
+# have secret/hub/imageregistry with account and token as keys with their associated
+# values (secrets)
 secrets:
   # NEVER COMMIT THESE VALUES TO GIT
   imageregistry:
@@ -28,5 +30,22 @@ secrets:
     server: https://api.example.openshiftapps.com:6443
     bearerToken: <bearer_token>
 
+# This will create the vault key secret/hub/cluster_example_ca which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
 files:
   cluster_example_ca: /path/to/ca.file
+
+# These secrets will be pushed in the vault at secret/region1/test The vault will
+# have secret/region1/test with secret1 and secret2 as keys with their associated
+# values (secrets)
+secrets.region1:
+  test:
+    secret1: foo1
+    secret2: bar1
+
+# This will create the vault key secret/region2/testbar which will have two
+# properties 'b64content' and 'content' which will be the base64-encoded
+# content and the normal content respectively
+files.region2:
+  testbar: ~/ca.crt

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -169,6 +169,8 @@ data:
     enabled: all
     files:
       cluster_example_ca: /path/to/ca.file
+    files.region2:
+      testbar: ~/ca.crt
     global:
       clusterDomain: region.example.com
       git:
@@ -206,8 +208,13 @@ data:
       imageregistry:
         account: test-account
         token: test-quay-token
+    secrets.region1:
+      test:
+        secret1: foo1
+        secret2: bar1
     secretsBase:
       key: secret/data/hub
+    version: 1
 ---
 # Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -1,6 +1,6 @@
 --- tests/clustergroup-naked.expected.yaml
 +++ tests/clustergroup-normal.expected.yaml
-@@ -1,17 +1,243 @@
+@@ -1,17 +1,250 @@
  ---
 +# Source: pattern-clustergroup/templates/core/namespaces.yaml
 +apiVersion: v1
@@ -174,6 +174,8 @@
 +    enabled: all
 +    files:
 +      cluster_example_ca: /path/to/ca.file
++    files.region2:
++      testbar: ~/ca.crt
 +    global:
 +      clusterDomain: region.example.com
 +      git:
@@ -211,8 +213,13 @@
 +      imageregistry:
 +        account: test-account
 +        token: test-quay-token
++    secrets.region1:
++      test:
++        secret1: foo1
++        secret2: bar1
 +    secretsBase:
 +      key: secret/data/hub
++    version: 1
 +---
 +# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
 +apiVersion: rbac.authorization.k8s.io/v1
@@ -246,7 +253,7 @@
  # Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
  # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
  apiVersion: rbac.authorization.k8s.io/v1
-@@ -36,7 +262,7 @@
+@@ -36,7 +269,7 @@
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
@@ -255,7 +262,7 @@
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -45,16 +271,583 @@
+@@ -45,16 +278,583 @@
    - kind: ServiceAccount
      # This is the {ArgoCD.name}-argocd-application-controller
      name: example-gitops-argocd-application-controller
@@ -842,7 +849,7 @@
  ---
  # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
  apiVersion: argoproj.io/v1alpha1
-@@ -65,7 +858,7 @@
+@@ -65,7 +865,7 @@
    # Changing the name affects the ClusterRoleBinding, the generated secret,
    # route URL, and argocd.argoproj.io/managed-by annotations
    name: example-gitops
@@ -851,7 +858,7 @@
    annotations:
      argocd.argoproj.io/compare-options: IgnoreExtraneous
  spec:
-@@ -94,10 +887,10 @@
+@@ -94,10 +894,10 @@
              --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
              --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
              --set global.namespace=$ARGOCD_APP_NAMESPACE
@@ -866,7 +873,7 @@
              --set clusterGroup.name=example
              --post-renderer ./kustomize"]
    applicationSet:
-@@ -174,11 +967,59 @@
+@@ -174,11 +974,59 @@
  kind: ConsoleLink
  metadata:
    name: example-gitops-link


### PR DESCRIPTION
- Add new ignores for python module
- Add python module implementing the push-secret functionality
- Switch push_secrets.yaml to the python module implementation
- Add more detail to the values-secret.yaml example
- Fix up tests after the secrets example change
- Tests cleanups
- Some more linting fixes
- Some more linting fixes pt2
- Pass black --skip-string-normalization over the python plugin
- Pass black --skip-string-normalization over ansible unit test
- Switched to full black formatting support
- Add some noqa: comments to ignore flake8
