### PR TITLE
Drop -f example/values-secrets.yaml from make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spe
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) \
 	--set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN) $(TARGET_SITE_OPT)
-TEST_OPTS= -f common/examples/values-secret.yaml -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" \
+TEST_OPTS= -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" \
 	--set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.pattern="mypattern" \
 	--set global.namespace="pattern-namespace" --set global.hubClusterDomain=apps.hub.example.com --set global.localClusterDomain=apps.region.example.com --set global.clusterDomain=region.example.com\
 	--set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" \

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -167,10 +167,6 @@ data:
           name: openshift-pipelines-operator-rh
       targetCluster: in-cluster
     enabled: all
-    files:
-      cluster_example_ca: /path/to/ca.file
-    files.region2:
-      testbar: ~/ca.crt
     global:
       clusterDomain: region.example.com
       git:
@@ -196,25 +192,8 @@ data:
     secretStore:
       kind: ClusterSecretStore
       name: vault-backend
-    secrets:
-      aws:
-        s3Secret: test-secret
-      cluster_example:
-        bearerToken: <bearer_token>
-        server: https://api.example.openshiftapps.com:6443
-      git:
-        token: test-git-token
-        username: test-user
-      imageregistry:
-        account: test-account
-        token: test-quay-token
-    secrets.region1:
-      test:
-        secret1: foo1
-        secret2: bar1
     secretsBase:
       key: secret/data/hub
-    version: 1
 ---
 # Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -1,6 +1,6 @@
 --- tests/clustergroup-naked.expected.yaml
 +++ tests/clustergroup-normal.expected.yaml
-@@ -1,17 +1,250 @@
+@@ -1,17 +1,229 @@
  ---
 +# Source: pattern-clustergroup/templates/core/namespaces.yaml
 +apiVersion: v1
@@ -172,10 +172,6 @@
 +          name: openshift-pipelines-operator-rh
 +      targetCluster: in-cluster
 +    enabled: all
-+    files:
-+      cluster_example_ca: /path/to/ca.file
-+    files.region2:
-+      testbar: ~/ca.crt
 +    global:
 +      clusterDomain: region.example.com
 +      git:
@@ -201,25 +197,8 @@
 +    secretStore:
 +      kind: ClusterSecretStore
 +      name: vault-backend
-+    secrets:
-+      aws:
-+        s3Secret: test-secret
-+      cluster_example:
-+        bearerToken: <bearer_token>
-+        server: https://api.example.openshiftapps.com:6443
-+      git:
-+        token: test-git-token
-+        username: test-user
-+      imageregistry:
-+        account: test-account
-+        token: test-quay-token
-+    secrets.region1:
-+      test:
-+        secret1: foo1
-+        secret2: bar1
 +    secretsBase:
 +      key: secret/data/hub
-+    version: 1
 +---
 +# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
 +apiVersion: rbac.authorization.k8s.io/v1
@@ -253,7 +232,7 @@
  # Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
  # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
  apiVersion: rbac.authorization.k8s.io/v1
-@@ -36,7 +269,7 @@
+@@ -36,7 +248,7 @@
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
@@ -262,7 +241,7 @@
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -45,16 +278,583 @@
+@@ -45,16 +257,583 @@
    - kind: ServiceAccount
      # This is the {ArgoCD.name}-argocd-application-controller
      name: example-gitops-argocd-application-controller
@@ -849,7 +828,7 @@
  ---
  # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
  apiVersion: argoproj.io/v1alpha1
-@@ -65,7 +865,7 @@
+@@ -65,7 +844,7 @@
    # Changing the name affects the ClusterRoleBinding, the generated secret,
    # route URL, and argocd.argoproj.io/managed-by annotations
    name: example-gitops
@@ -858,7 +837,7 @@
    annotations:
      argocd.argoproj.io/compare-options: IgnoreExtraneous
  spec:
-@@ -94,10 +894,10 @@
+@@ -94,10 +873,10 @@
              --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
              --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
              --set global.namespace=$ARGOCD_APP_NAMESPACE
@@ -873,7 +852,7 @@
              --set clusterGroup.name=example
              --post-renderer ./kustomize"]
    applicationSet:
-@@ -174,11 +974,59 @@
+@@ -174,11 +953,59 @@
  kind: ConsoleLink
  metadata:
    name: example-gitops-link


### PR DESCRIPTION
We should *never* ever pass values-secrets.yaml to helm. As that file is
injected to vault out-of-band and has nothing to do with helm at all.
