### PR TITLE
Drop GIT_SSH_COMMAND from the wrapper

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -24,7 +24,6 @@ podman run -it \
 	--security-opt label=disable \
 	-e KUBECONFIG="${KUBECONFIG}" \
 	${SSH_SOCK_MOUNTS} \
-	-e GIT_SSH_COMMAND="ssh -o IgnoreUnknown=pubkeyacceptedalgorithms" \
 	-v ${HOME}:/home/runner \
 	-v ${HOME}:${HOME} \
 	-v ${HOME}:/root \


### PR DESCRIPTION
It breaks on Silverblue with:

 ./common/scripts/pattern-util.sh make push-secrets                                                                                                          ─╯
  Error: unknown shorthand flag: 'o' in -o
  See 'podman run --help'
