### PR TITLE
Update to sanitize_values function in vault_load_secrets.py

### DIFF
--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -191,9 +191,13 @@ def sanitize_values(module, syaml):
 
     secrets = syaml.get("secrets", {})
     files = syaml.get("files", {})
-    if len(secrets) == 0 and len(files) == 0:
+    if len(secrets) == 0:
         module.fail_json(
-            f"Neither 'secrets' nor 'files have any secrets to " f"be parsed: {syaml}"
+            f"The 'secrets' section is empty and does not have any secrets to " f"be parsed: {syaml}"
+        )
+    if len(files) == 0:
+        module.fail_json(
+            f"The 'files' section is empty and does not have any secrets to " f"be parsed: {syaml}"
         )
 
     for secret in secrets:


### PR DESCRIPTION
- Updated the sanitize_values function. Specifically in the if statement:
```
secrets = syaml.get("secrets", {})
files = syaml.get("files", {})
if len(secrets) == 0 and len(files) == 0:
module.fail_json(
f"Neither 'secrets' nor 'files have any secrets to " f"be parsed: {syaml}"
)
```
- Splitted the if statement to generate a better error:

```
secrets = syaml.get("secrets", {})
files = syaml.get("files", {})
if len(secrets) == 0:
module.fail_json(
f"The 'secrets' section is empty and does not have any secrets to " f"be parsed: {syaml}"
)
if len(files) == 0:
module.fail_json(
f"The 'files' section is empty and does not have any secrets to " f"be parsed: {syaml}"
)
```

This will generate the following error if the files section is empty:
```
$ ansible-playbook load-secrets.yaml

PLAY [localhost] **********************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Loads secrets file into the vault of a cluster] *********************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "The 'files' section is empty and does not have any secrets to be parsed: {'secrets': {'imageregistry': {'username': 'claudiol+ops', 'password': 'REDACTED'}, 'quay': {'account': 'qyadmin', 'password': 'REDACTED', 'email': 'quayadmin@example.com'}, 'git': {'username': 'claudiol', 'password': 'ghp_REDACTED'}, 'aws': {'s3Secret': 'REDACTED'}, 'config-demo': {'secret': 'MySup3rR3dh4tP@$$W0rd'}, 'files': None}}"}

PLAY RECAP ****************************************************************************************************************************************************************************************************************
localhost : ok=1 changed=0 unreachable=0 failed=1 skipped=0 rescued=0 ignored=0
```