### PR TITLE
Fix #184 (empty files: key)

### DIFF
--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -121,7 +121,7 @@ def parse_values(values_file):
     """
     with open(values_file, "r", encoding="utf-8") as file:
         secrets_yaml = yaml.safe_load(file.read())
-    if secrets_yaml == None:
+    if secrets_yaml is None:
         return {}
     return secrets_yaml
 
@@ -195,10 +195,10 @@ def sanitize_values(module, syaml):
     # We need to explicitely check for None because the file might contain the
     # top-level 'secrets:' or 'files:' key but have nothing else under it which will
     # return None and not {}
-    if secrets == None:
+    if secrets is None:
         secrets = {}
     files = syaml.get("files", {})
-    if files == None:
+    if files is None:
         files = {}
     if len(secrets) == 0 and len(files) == 0:
         module.fail_json(

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -121,6 +121,8 @@ def parse_values(values_file):
     """
     with open(values_file, "r", encoding="utf-8") as file:
         secrets_yaml = yaml.safe_load(file.read())
+    if secrets_yaml == None:
+        return {}
     return secrets_yaml
 
 

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -214,7 +214,7 @@ def sanitize_values(module, syaml):
 
     for file in files:
         path = files[file]
-        if not os.path.isfile(path):
+        if not os.path.isfile(os.path.expanduser(path)):
             module.fail_json(f"File {path} does not exist")
 
     # If s3Secret key does not exist but s3.accessKey and s3.secretKey do exist

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -90,6 +90,94 @@ class TestMyModule(unittest.TestCase):
             ret["msg"], "Values secrets file does not exist: /tmp/nonexisting"
         )
 
+    def test_ensure_empty_files_but_not_secrets_is_ok(self):
+        set_module_args(
+            {
+                "values_secrets": os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "values-secret-empty-files.yaml"
+                )
+            }
+        )
+
+        with patch.object(vault_load_secrets, "run_command") as mock_run_command:
+            stdout = "configuration updated"
+            stderr = ""
+            ret = 0
+            mock_run_command.return_value = ret, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                vault_load_secrets.main()
+            self.assertTrue(
+                result.exception.args[0]["changed"]
+            )  # ensure result is changed
+            assert mock_run_command.call_count == 2
+
+        calls = [
+            call(
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='VALUE'\""  # noqa: E501
+            ),
+            call(
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/aws' access_key_id='VALUE' secret_access_key='VALUE'\""  # noqa: E501
+            ),
+        ]
+        mock_run_command.assert_has_calls(calls)
+
+    def test_ensure_broken1_file_fails(self):
+        with self.assertRaises(AnsibleFailJson) as ansible_err:
+            set_module_args(
+                {
+                    "values_secrets": os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)), "values-secret-broken1.yaml"
+                    )
+                }
+            )
+            vault_load_secrets.main()
+
+        ret = ansible_err.exception.args[0]
+        self.assertEqual(ret["failed"], True)
+
+    def test_ensure_broken2_file_fails(self):
+        with self.assertRaises(AnsibleFailJson) as ansible_err:
+            set_module_args(
+                {
+                    "values_secrets": os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)), "values-secret-broken2.yaml"
+                    )
+                }
+            )
+            vault_load_secrets.main()
+
+        ret = ansible_err.exception.args[0]
+        self.assertEqual(ret["failed"], True)
+
+    def test_ensure_empty_secrets_but_not_files_is_ok(self):
+        set_module_args(
+            {
+                "values_secrets": os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "values-secret-empty-secrets.yaml"
+                )
+            }
+        )
+
+        with patch.object(vault_load_secrets, "run_command") as mock_run_command:
+            stdout = "configuration updated"
+            stderr = ""
+            ret = 0
+            mock_run_command.return_value = ret, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                vault_load_secrets.main()
+            self.assertTrue(
+                result.exception.args[0]["changed"]
+            )  # ensure result is changed
+            assert mock_run_command.call_count == 1
+
+        calls = [
+            call(
+                "cat '/home/michele/.ssh/id_rsa.pub' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/publickey b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
+            ),
+        ]
+        mock_run_command.assert_has_calls(calls)
     def test_ensure_command_called(self):
         set_module_args(
             {

--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -94,7 +94,8 @@ class TestMyModule(unittest.TestCase):
         set_module_args(
             {
                 "values_secrets": os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), "values-secret-empty-files.yaml"
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "values-secret-empty-files.yaml",
                 )
             }
         )
@@ -127,7 +128,8 @@ class TestMyModule(unittest.TestCase):
             set_module_args(
                 {
                     "values_secrets": os.path.join(
-                        os.path.dirname(os.path.abspath(__file__)), "values-secret-broken1.yaml"
+                        os.path.dirname(os.path.abspath(__file__)),
+                        "values-secret-broken1.yaml",
                     )
                 }
             )
@@ -141,7 +143,8 @@ class TestMyModule(unittest.TestCase):
             set_module_args(
                 {
                     "values_secrets": os.path.join(
-                        os.path.dirname(os.path.abspath(__file__)), "values-secret-broken2.yaml"
+                        os.path.dirname(os.path.abspath(__file__)),
+                        "values-secret-broken2.yaml",
                     )
                 }
             )
@@ -154,7 +157,8 @@ class TestMyModule(unittest.TestCase):
         set_module_args(
             {
                 "values_secrets": os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), "values-secret-empty-secrets.yaml"
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "values-secret-empty-secrets.yaml",
                 )
             }
         )
@@ -178,6 +182,7 @@ class TestMyModule(unittest.TestCase):
             ),
         ]
         mock_run_command.assert_has_calls(calls)
+
     def test_ensure_command_called(self):
         set_module_args(
             {

--- a/ansible/tests/unit/values-secret-broken1.yaml
+++ b/ansible/tests/unit/values-secret-broken1.yaml
@@ -1,0 +1,6 @@
+---
+secrets:
+  # empty
+
+files:
+  # empty

--- a/ansible/tests/unit/values-secret-broken2.yaml
+++ b/ansible/tests/unit/values-secret-broken2.yaml
@@ -1,6 +1,6 @@
 ---
-#secrets:
-  # empty
+# secrets:
+#   empty
 
-#files:
-  # empty
+# files:
+#   empty

--- a/ansible/tests/unit/values-secret-broken2.yaml
+++ b/ansible/tests/unit/values-secret-broken2.yaml
@@ -1,0 +1,6 @@
+---
+#secrets:
+  # empty
+
+#files:
+  # empty

--- a/ansible/tests/unit/values-secret-empty-files.yaml
+++ b/ansible/tests/unit/values-secret-empty-files.yaml
@@ -7,8 +7,8 @@ secrets:
 
   # Required for automated spoke deployment
   aws:
-      access_key_id: VALUE
-      secret_access_key: VALUE
+    access_key_id: VALUE
+    secret_access_key: VALUE
 
 # Required for automated spoke deployment
 files:

--- a/ansible/tests/unit/values-secret-empty-files.yaml
+++ b/ansible/tests/unit/values-secret-empty-files.yaml
@@ -1,0 +1,16 @@
+---
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  config-demo:
+    # Secret used for demonstrating vault storage, external secrets, and ACM distribution
+    secret: VALUE
+
+  # Required for automated spoke deployment
+  aws:
+      access_key_id: VALUE
+      secret_access_key: VALUE
+
+# Required for automated spoke deployment
+files:
+  # # ssh-rsa AAA...
+  # publickey: ~/.ssh/id_rsa.pub

--- a/ansible/tests/unit/values-secret-empty-secrets.yaml
+++ b/ansible/tests/unit/values-secret-empty-secrets.yaml
@@ -1,0 +1,16 @@
+---
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  # config-demo:
+  #   # Secret used for demonstrating vault storage, external secrets, and ACM distribution
+  #   secret: VALUE
+
+  # # Required for automated spoke deployment
+  # aws:
+  #     access_key_id: VALUE
+  #     secret_access_key: VALUE
+
+# Required for automated spoke deployment
+files:
+  # # ssh-rsa AAA...
+  publickey: ~/.ssh/id_rsa.pub


### PR DESCRIPTION
- Return {} when parsing an empty yaml file
- Make sure to skip loops that have None in their range
- Make sure to expand user path when checking for file existence
- Add a number of testcases that cover corner cases in the values files
- Fix up flake8 and black warnings
