### PR TITLE
Additional unittests and another yaml cornercase

### DIFF
--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -206,10 +206,7 @@ def sanitize_values(module, syaml):
         )
 
     if isinstance(secrets, list) or isinstance(files, list):
-        module.fail_json(
-            f"Neither 'secrets' nor 'files can be lists: {syaml}"
-        )
-
+        module.fail_json(f"Neither 'secrets' nor 'files can be lists: {syaml}")
 
     for secret in secrets:
         if not isinstance(secrets[secret], dict):

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -202,8 +202,14 @@ def sanitize_values(module, syaml):
         files = {}
     if len(secrets) == 0 and len(files) == 0:
         module.fail_json(
-            f"Neither 'secrets' nor 'files have any secrets to " f"be parsed: {syaml}"
+            f"Neither 'secrets' nor 'files have any secrets to be parsed: {syaml}"
         )
+
+    if isinstance(secrets, list) or isinstance(files, list):
+        module.fail_json(
+            f"Neither 'secrets' nor 'files can be lists: {syaml}"
+        )
+
 
     for secret in secrets:
         if not isinstance(secrets[secret], dict):

--- a/ansible/tests/unit/values-secret-broken3.yaml
+++ b/ansible/tests/unit/values-secret-broken3.yaml
@@ -1,0 +1,9 @@
+---
+secrets:
+  - borked1
+  - borked2
+
+files:
+  foo:
+    - broken
+    - broken2


### PR DESCRIPTION
- Cleanup tests and bail out properly when files/secrets: are lists
- Reformat isinstance list fail message
