### PR TITLE
Added callbacks to ansible.cfg

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,4 +3,4 @@ display_skipped_hosts=False
 localhost_warning=False
 library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-callback_whitelist = profile_roles, profile_tasks
+callbacks_enabled = profile_roles, profile_tasks

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,3 +3,4 @@ display_skipped_hosts=False
 localhost_warning=False
 library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+callback_whitelist = profile_roles, profile_tasks


### PR DESCRIPTION
The profile_roles and profile_tasks callbacks provide timinng
information for tasks and roles to execute.
