### PR TITLE
verify local secret template

### DIFF
--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -51,9 +51,9 @@ files.region2:
 """
 
 import base64
-from collections.abc import MutableMapping
 import os
 import subprocess
+from collections.abc import MutableMapping
 
 import yaml
 from ansible.module_utils.basic import AnsibleModule

--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -51,6 +51,7 @@ files.region2:
 """
 
 import base64
+from collections.abc import MutableMapping
 import os
 import subprocess
 
@@ -95,6 +96,19 @@ options:
     required: false
     type: str
     default: secret
+  check_missing_secrets:
+    description:
+      - Validate the ~/values-secret.yaml file against the top-level
+        values-secret-template.yaml and error out if secrets are missing
+    required: false
+    type: bool
+    default: False
+  values_secret_template:
+    description:
+      - Path of the values-secret-template.yaml file of the pattern
+    required: false
+    type: str
+    default: ""
 """
 
 RETURN = """
@@ -158,6 +172,38 @@ def run_command(command):
         check=True,
     )
     return ret
+
+
+def flatten(dictionary, parent_key=False, separator="."):
+    """
+    Turn a nested dictionary into a flattened dictionary and also
+    drop any key that has 'None' as their value
+
+    Parameters:
+        dictionary(dict): The dictionary to flatten
+
+        parent_key(str): The string to prepend to dictionary's keys
+
+        separator(str): The string used to separate flattened keys
+
+    Returns:
+
+        dictionary: A flattened dictionary where the keys represent the
+        path to reach the leaves
+    """
+
+    items = []
+    for key, value in dictionary.items():
+        new_key = str(parent_key) + separator + key if parent_key else key
+        if isinstance(value, MutableMapping):
+            items.extend(flatten(value, new_key, separator).items())
+        elif isinstance(value, list):
+            for k, v in enumerate(value):
+                items.extend(flatten({str(k): v}, new_key).items())
+        else:
+            if value is not None:
+                items.append((new_key, value))
+    return dict(items)
 
 
 def sanitize_values(module, syaml):
@@ -339,6 +385,27 @@ def inject_secrets(module, syaml, namespace, pod, basepath):
     return counter
 
 
+def check_for_missing_secrets(module, syaml, values_secret_template):
+    with open(values_secret_template, "r", encoding="utf-8") as file:
+        template_yaml = yaml.safe_load(file.read())
+    if template_yaml is None:
+        module.fail_json(f"Template {values_secret_template} is empty")
+
+    syaml_flat = flatten(syaml)
+    template_flat = flatten(template_yaml)
+
+    syaml_keys = set(syaml_flat.keys())
+    template_keys = set(template_flat.keys())
+
+    if template_keys <= syaml_keys:
+        return
+
+    diff = template_keys - syaml_keys
+    module.fail_json(
+        f"Values secret yaml is missing needed secrets from the templates: {diff}"
+    )
+
+
 def run(module):
     """Main ansible module entry point"""
     results = dict(changed=False)
@@ -348,6 +415,12 @@ def run(module):
     basepath = args.get("basepath")
     namespace = args.get("namespace")
     pod = args.get("pod")
+    check_missing_secrets = args.get("check_missing_secrets")
+    values_secret_template = args.get("values_secret_template")
+    if check_missing_secrets and values_secret_template == "":
+        module.fail_json(
+            "No values_secret_template defined and check_missing_secrets set to True"
+        )
 
     if not os.path.exists(values_secrets):
         results["failed"] = True
@@ -363,6 +436,12 @@ def run(module):
 
     # In the future we can use the version field to manage different formats if needed
     secrets = sanitize_values(module, syaml)
+
+    # If the user specified check_for_missing_secrets then we read values_secret_template
+    # and check if there are any missing secrets
+    if check_missing_secrets:
+        check_for_missing_secrets(module, syaml, values_secret_template)
+
     nr_secrets = inject_secrets(module, secrets, namespace, pod, basepath)
     results["failed"] = False
     results["changed"] = True

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -41,5 +41,5 @@
 - name: Loads secrets file into the vault of a cluster
   vault_load_secrets:
     values_secrets: ~/values-secret.yaml
-    check_missing_secrets: False
+    check_missing_secrets: false
     values_secret_template: "{{ secret_template }}"

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -34,6 +34,12 @@
   delay: 45
   changed_when: false
 
+- name: Set secret_template fact
+  ansible.builtin.set_fact:
+    secret_template: "{{ pattern_dir }}/values-secret.yaml.template"
+
 - name: Loads secrets file into the vault of a cluster
   vault_load_secrets:
     values_secrets: ~/values-secret.yaml
+    check_missing_secrets: False
+    values_secret_template: "{{ secret_template }}"

--- a/ansible/tests/unit/mcg-values-secret.yaml
+++ b/ansible/tests/unit/mcg-values-secret.yaml
@@ -7,7 +7,7 @@ secrets:
     additionalsecret: test
 
   # Required for automated spoke deployment
-  #aws:
+  # aws:
   #    access_key_id: VALUE
   #    secret_access_key: VALUE
 

--- a/ansible/tests/unit/mcg-values-secret.yaml
+++ b/ansible/tests/unit/mcg-values-secret.yaml
@@ -1,0 +1,27 @@
+---
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  config-demo:
+    # Secret used for demonstrating vault storage, external secrets, and ACM distribution
+    secret: VALUE
+    additionalsecret: test
+
+  # Required for automated spoke deployment
+  #aws:
+  #    access_key_id: VALUE
+  #    secret_access_key: VALUE
+
+# Required for automated spoke deployment
+files:
+  # # ssh-rsa AAA...
+  # publickey: ~/.ssh/id_rsa.pub
+  #
+  # # -----BEGIN RSA PRIVATE KEY
+  # # ...
+  # # -----END RSA PRIVATE KEY
+  # privatekey: ~/.ssh/id_rsa
+  #
+  # # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
+  # openshiftPullSecret: ~/.dockerconfigjson
+  #
+  # azureOsServicePrincipal: ~/osServicePrincipal.json

--- a/ansible/tests/unit/template-mcg-missing.yaml
+++ b/ansible/tests/unit/template-mcg-missing.yaml
@@ -1,5 +1,4 @@
 ---
-# This template file 
 secrets:
   # NEVER COMMIT THESE VALUES TO GIT
   config-demo:
@@ -8,7 +7,7 @@ secrets:
     foo: bar
 
   # Required for automated spoke deployment
-  #aws:
+  # aws:
   #    access_key_id: VALUE
   #    secret_access_key: VALUE
 

--- a/ansible/tests/unit/template-mcg-missing.yaml
+++ b/ansible/tests/unit/template-mcg-missing.yaml
@@ -1,0 +1,28 @@
+---
+# This template file 
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  config-demo:
+    # Secret used for demonstrating vault storage, external secrets, and ACM distribution
+    secret: VALUE
+    foo: bar
+
+  # Required for automated spoke deployment
+  #aws:
+  #    access_key_id: VALUE
+  #    secret_access_key: VALUE
+
+# Required for automated spoke deployment
+files:
+  # # ssh-rsa AAA...
+  # publickey: ~/.ssh/id_rsa.pub
+  #
+  # # -----BEGIN RSA PRIVATE KEY
+  # # ...
+  # # -----END RSA PRIVATE KEY
+  # privatekey: ~/.ssh/id_rsa
+  #
+  # # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
+  # openshiftPullSecret: ~/.dockerconfigjson
+  #
+  # azureOsServicePrincipal: ~/osServicePrincipal.json

--- a/ansible/tests/unit/template-mcg-working.yaml
+++ b/ansible/tests/unit/template-mcg-working.yaml
@@ -6,7 +6,7 @@ secrets:
     secret: VALUE
 
   # Required for automated spoke deployment
-  #aws:
+  # aws:
   #    access_key_id: VALUE
   #    secret_access_key: VALUE
 

--- a/ansible/tests/unit/template-mcg-working.yaml
+++ b/ansible/tests/unit/template-mcg-working.yaml
@@ -1,0 +1,26 @@
+---
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  config-demo:
+    # Secret used for demonstrating vault storage, external secrets, and ACM distribution
+    secret: VALUE
+
+  # Required for automated spoke deployment
+  #aws:
+  #    access_key_id: VALUE
+  #    secret_access_key: VALUE
+
+# Required for automated spoke deployment
+files:
+  # # ssh-rsa AAA...
+  # publickey: ~/.ssh/id_rsa.pub
+  #
+  # # -----BEGIN RSA PRIVATE KEY
+  # # ...
+  # # -----END RSA PRIVATE KEY
+  # privatekey: ~/.ssh/id_rsa
+  #
+  # # {"auths":{"cloud.openshift.com":{"auth":"b3Blb... }}}
+  # openshiftPullSecret: ~/.dockerconfigjson
+  #
+  # azureOsServicePrincipal: ~/osServicePrincipal.json

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -7,8 +7,9 @@ get_abs_filename() {
 }
 
 SCRIPT=$(get_abs_filename "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-COMMONPATH=$(dirname "$SCRIPTPATH")
+SCRIPTPATH=$(dirname "${SCRIPT}")
+COMMONPATH=$(dirname "${SCRIPTPATH}")
+PATTERNPATH=$(dirname "${COMMONPATH}")
 ANSIBLEPATH="$(dirname ${SCRIPTPATH})/ansible"
 PLAYBOOKPATH="${ANSIBLEPATH}/playbooks"
 export ANSIBLE_CONFIG="${ANSIBLEPATH}/ansible.cfg"
@@ -27,4 +28,4 @@ if [ -z ${TASK} ]; then
 	exit 1
 fi
 
-ansible-playbook -t "${TASK}" -e output_file="${OUTFILE}" "${PLAYBOOKPATH}/vault/vault.yaml"
+ansible-playbook -t "${TASK}" -e pattern_dir="${PATTERNPATH}" -e output_file="${OUTFILE}" "${PLAYBOOKPATH}/vault/vault.yaml"


### PR DESCRIPTION
- Add a pattern_dir variable to the playbook
- Add a check a check_missing_secrets parameter to vault_load_secrets
- Add a number of unit tests to verify the new check_missing_secrets functionality
- Add all the code to actually verify secrets against values-secret-template.yaml but keep it disabled
- Fix a couple of linting issues
