### PR TITLE
Implement global.clusterVersion

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,13 @@
 # Changes
 
+## October 13, 2022
+
+* Added global.clusterVersion as a new helm variable which represents the OCP
+  Major.Minor cluster version. By default now a user can add a
+  values-<ocpversion>-<clustergroup>.yaml file to have specific cluster version
+  overrides (e.g. values-4.10-hub.yaml). Will need Validated Patterns >= 0.0.6
+  when deploying with the operator.
+
 ## October 4, 2022
 
 * Extended the values-secret.yaml file to support multiple vault paths and re-wrote

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,8 @@
   Major.Minor cluster version. By default now a user can add a
   values-<ocpversion>-<clustergroup>.yaml file to have specific cluster version
   overrides (e.g. values-4.10-hub.yaml). Will need Validated Patterns Operator >= 0.0.6
-  when deploying with the operator.
+  when deploying with the operator. Note: When using the ArgoCD Hub and spoke model,
+  you cannot have spokes with a different version of OCP than the hub.
 
 ## October 4, 2022
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@
 * Added global.clusterVersion as a new helm variable which represents the OCP
   Major.Minor cluster version. By default now a user can add a
   values-<ocpversion>-<clustergroup>.yaml file to have specific cluster version
-  overrides (e.g. values-4.10-hub.yaml). Will need Validated Patterns >= 0.0.6
+  overrides (e.g. values-4.10-hub.yaml). Will need Validated Patterns Operator >= 0.0.6
   when deploying with the operator.
 
 ## October 4, 2022

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ TARGET_REPO=$(shell git remote show $(TARGET_ORIGIN) | grep Push | sed -e 's/.*U
 # git branch --show-current is also available as of git 2.22, but we will use this for compatibility
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 HUBCLUSTER_APPS_DOMAIN=$(shell oc get ingresses.config/cluster -o jsonpath={.spec.domain})
+HUBCLUSTER_VERSION=$(shell oc get OpenShiftControllerManager/cluster -o jsonpath='{.status.version}' | sed -n -E 's/([0-9]+).([0-9]+).*/\1.\2/p')
 
 # --set values always take precedence over the contents of -f
 HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) \
-	--set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN) $(TARGET_SITE_OPT)
+	--set global.hubClusterDomain=$(HUBCLUSTER_APPS_DOMAIN) --set global.clusterVersion="$(HUBCLUSTER_VERSION)" $(TARGET_SITE_OPT)
 TEST_OPTS= -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" \
 	--set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.pattern="mypattern" \
 	--set global.namespace="pattern-namespace" --set global.hubClusterDomain=apps.hub.example.com --set global.localClusterDomain=apps.region.example.com --set global.clusterDomain=region.example.com\

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -45,9 +45,9 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
-                      {{- if $.Values.global.clusterVersion }}
-                      - "/values-{{ $.Values.global.clusterVersion }}-{{ .name }}.yaml"
-                      {{- end }}
+                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                      # hub's cluster version, whereas we want to include the spoke cluster version
+                      - '/values-{{ `{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}` }}-{{ .name }}.yaml'
                       {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -45,6 +45,9 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
+                      {{- if $.Values.global.clusterVersion }}
+                      - "/values-{{ $.Values.global.clusterVersion }}-{{ .name }}.yaml"
+                      {{- end }}
                       {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}
@@ -64,6 +67,9 @@ spec:
                       # Requires ACM 2.6 or higher
                       - name: global.clusterDomain
                         value: '{{ `{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}` }}'
+                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
+                      - name: global.clusterVersion
+                        value: '{{ `{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}` }}'
                       - name: clusterGroup.name
                         value: {{ $group.name }}
                      {{- range .helmOverrides }}

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -47,7 +47,7 @@ spec:
                       - "/values-{{ .name }}.yaml"
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
-                      - '/values-{{ `{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}` }}-{{ .name }}.yaml'
+                      - '/values-{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}-{{ .name }}.yaml'
                       {{- range $valueFile := .extraValueFiles }}
                       - {{ $valueFile | quote }}
                       {{- end }}
@@ -69,7 +69,7 @@ spec:
                         value: '{{ `{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}` }}'
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
-                        value: '{{ `{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}` }}'
+                        value: '{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}'
                       - name: clusterGroup.name
                         value: {{ $group.name }}
                      {{- range .helmOverrides }}

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -56,6 +56,9 @@ spec:
           ignoreMissingValueFiles: true
           valueFiles:
             - "values.yaml"
+            {{- if $.Values.global.clusterVersion }}
+            - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
+            {{- end }}
         {{- range .extraValueFiles }}
             - {{ . | quote }}
         {{- end }}
@@ -66,6 +69,8 @@ spec:
           parameters:
             - name: global.clusterDomain
               value: {{ $.Values.global.clusterDomain }}
+            - name: global.clusterVersion
+              value: "{{ $.Values.global.clusterVersion }}"
             - name: global.hubClusterDomain
               value: {{ $.Values.global.hubClusterDomain }}
             - name: global.localClusterDomain
@@ -144,6 +149,9 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- if $.Values.global.clusterVersion }}
+      - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- end }}
       {{- range $valueFile := .extraValueFiles }}
       - {{ $valueFile | quote }}
       {{- end }}
@@ -159,6 +167,8 @@ spec:
           value: {{ $.Values.global.pattern }}
         - name: global.clusterDomain
           value: {{ $.Values.global.clusterDomain }}
+        - name: global.clusterVersion
+          value: "{{ $.Values.global.clusterVersion }}"
         - name: global.hubClusterDomain
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain

--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -19,6 +19,9 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-{{ .Values.main.clusterGroupName }}.yaml"
+      {{- if .Values.global.clusterVersion }}
+      - "/values-{{ .Values.global.clusterVersion }}-{{ .Values.main.clusterGroupName }}.yaml"
+      {{- end }}
       # Track the progress of https://github.com/argoproj/argo-cd/pull/6280
       parameters:
         - name: global.repoURL
@@ -31,6 +34,8 @@ spec:
           value: {{ .Release.Name }}
         - name: global.hubClusterDomain
           value: {{ .Values.global.hubClusterDomain }}
+        - name: global.clusterVersion
+          value: "{{ .Values.global.clusterVersion }}"
 {{- if eq .Values.main.options.syncPolicy "Automatic" }}
   syncPolicy:
     automated: {}

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -543,6 +543,9 @@ spec:
                       # Requires ACM 2.6 or higher
                       - name: global.clusterDomain
                         value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
+                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
+                      - name: global.clusterVersion
+                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
                       - name: clusterGroup.name
                         value: acm-edge
                       - name: clusterGroup.isHubCluster
@@ -624,6 +627,9 @@ spec:
                       # Requires ACM 2.6 or higher
                       - name: global.clusterDomain
                         value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
+                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
+                      - name: global.clusterVersion
+                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
                       - name: clusterGroup.name
                         value: acm-provision-edge
                       - name: clusterGroup.isHubCluster

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -529,7 +529,7 @@ spec:
                       - "/values-acm-edge.yaml"
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
-                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-edge.yaml'
+                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-edge.yaml'
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -548,7 +548,7 @@ spec:
                         value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
-                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
+                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
                       - name: clusterGroup.name
                         value: acm-edge
                       - name: clusterGroup.isHubCluster
@@ -616,7 +616,7 @@ spec:
                       - "/values-acm-provision-edge.yaml"
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
-                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-provision-edge.yaml'
+                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-provision-edge.yaml'
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -635,7 +635,7 @@ spec:
                         value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
-                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
+                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
                       - name: clusterGroup.name
                         value: acm-provision-edge
                       - name: clusterGroup.isHubCluster

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -527,6 +527,9 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                      # hub's cluster version, whereas we want to include the spoke cluster version
+                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-edge.yaml'
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -611,6 +614,9 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
+                      # hub's cluster version, whereas we want to include the spoke cluster version
+                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-provision-edge.yaml'
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/acm.expected.diff
+++ b/tests/acm.expected.diff
@@ -461,7 +461,7 @@
  # Source: acm/templates/policies/ocp-gitops-policy.yaml
  apiVersion: apps.open-cluster-management.io/v1
  kind: PlacementRule
-@@ -44,6 +482,169 @@
+@@ -44,6 +482,175 @@
          values:
            - OpenShift
  ---
@@ -526,6 +526,9 @@
 +                      # Requires ACM 2.6 or higher
 +                      - name: global.clusterDomain
 +                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
++                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
++                      - name: global.clusterVersion
++                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
 +                      - name: clusterGroup.name
 +                        value: acm-edge
 +                      - name: clusterGroup.isHubCluster
@@ -607,6 +610,9 @@
 +                      # Requires ACM 2.6 or higher
 +                      - name: global.clusterDomain
 +                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
++                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
++                      - name: global.clusterVersion
++                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
 +                      - name: clusterGroup.name
 +                        value: acm-provision-edge
 +                      - name: clusterGroup.isHubCluster

--- a/tests/acm.expected.diff
+++ b/tests/acm.expected.diff
@@ -512,7 +512,7 @@
 +                      - "/values-acm-edge.yaml"
 +                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
 +                      # hub's cluster version, whereas we want to include the spoke cluster version
-+                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-edge.yaml'
++                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-edge.yaml'
 +                      parameters:
 +                      - name: global.repoURL
 +                        value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -531,7 +531,7 @@
 +                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
 +                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
 +                      - name: global.clusterVersion
-+                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
++                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
 +                      - name: clusterGroup.name
 +                        value: acm-edge
 +                      - name: clusterGroup.isHubCluster
@@ -599,7 +599,7 @@
 +                      - "/values-acm-provision-edge.yaml"
 +                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
 +                      # hub's cluster version, whereas we want to include the spoke cluster version
-+                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-provision-edge.yaml'
++                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-provision-edge.yaml'
 +                      parameters:
 +                      - name: global.repoURL
 +                        value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -618,7 +618,7 @@
 +                        value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain | replace "apps." "" }}'
 +                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
 +                      - name: global.clusterVersion
-+                        value: '{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}'
++                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
 +                      - name: clusterGroup.name
 +                        value: acm-provision-edge
 +                      - name: clusterGroup.isHubCluster

--- a/tests/acm.expected.diff
+++ b/tests/acm.expected.diff
@@ -461,7 +461,7 @@
  # Source: acm/templates/policies/ocp-gitops-policy.yaml
  apiVersion: apps.open-cluster-management.io/v1
  kind: PlacementRule
-@@ -44,6 +482,175 @@
+@@ -44,6 +482,181 @@
          values:
            - OpenShift
  ---
@@ -510,6 +510,9 @@
 +                      valueFiles:
 +                      - "/values-global.yaml"
 +                      - "/values-acm-edge.yaml"
++                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
++                      # hub's cluster version, whereas we want to include the spoke cluster version
++                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-edge.yaml'
 +                      parameters:
 +                      - name: global.repoURL
 +                        value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -594,6 +597,9 @@
 +                      valueFiles:
 +                      - "/values-global.yaml"
 +                      - "/values-acm-provision-edge.yaml"
++                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
++                      # hub's cluster version, whereas we want to include the spoke cluster version
++                      - '/values-{{ (cat (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major (semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) | replace " " "." }}-acm-provision-edge.yaml'
 +                      parameters:
 +                      - name: global.repoURL
 +                        value: $ARGOCD_APP_SOURCE_REPO_URL

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -528,6 +528,8 @@ spec:
           value: mypattern
         - name: global.clusterDomain
           value: region.example.com
+        - name: global.clusterVersion
+          value: ""
         - name: global.hubClusterDomain
           value: apps.hub.example.com
         - name: global.localClusterDomain
@@ -579,6 +581,8 @@ spec:
           value: mypattern
         - name: global.clusterDomain
           value: region.example.com
+        - name: global.clusterVersion
+          value: ""
         - name: global.hubClusterDomain
           value: apps.hub.example.com
         - name: global.localClusterDomain

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -241,7 +241,7 @@
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -45,16 +257,583 @@
+@@ -45,16 +257,587 @@
    - kind: ServiceAccount
      # This is the {ArgoCD.name}-argocd-application-controller
      name: example-gitops-argocd-application-controller
@@ -519,6 +519,8 @@
 +          value: mypattern
 +        - name: global.clusterDomain
 +          value: region.example.com
++        - name: global.clusterVersion
++          value: ""
 +        - name: global.hubClusterDomain
 +          value: apps.hub.example.com
 +        - name: global.localClusterDomain
@@ -570,6 +572,8 @@
 +          value: mypattern
 +        - name: global.clusterDomain
 +          value: region.example.com
++        - name: global.clusterVersion
++          value: ""
 +        - name: global.hubClusterDomain
 +          value: apps.hub.example.com
 +        - name: global.localClusterDomain
@@ -828,7 +832,7 @@
  ---
  # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
  apiVersion: argoproj.io/v1alpha1
-@@ -65,7 +844,7 @@
+@@ -65,7 +848,7 @@
    # Changing the name affects the ClusterRoleBinding, the generated secret,
    # route URL, and argocd.argoproj.io/managed-by annotations
    name: example-gitops
@@ -837,7 +841,7 @@
    annotations:
      argocd.argoproj.io/compare-options: IgnoreExtraneous
  spec:
-@@ -94,10 +873,10 @@
+@@ -94,10 +877,10 @@
              --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
              --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
              --set global.namespace=$ARGOCD_APP_NAMESPACE
@@ -852,7 +856,7 @@
              --set clusterGroup.name=example
              --post-renderer ./kustomize"]
    applicationSet:
-@@ -174,11 +953,59 @@
+@@ -174,11 +957,59 @@
  kind: ConsoleLink
  metadata:
    name: example-gitops-link

--- a/tests/install-naked.expected.yaml
+++ b/tests/install-naked.expected.yaml
@@ -41,6 +41,8 @@ spec:
           value: install
         - name: global.hubClusterDomain
           value: 
+        - name: global.clusterVersion
+          value: ""
   syncPolicy:
     automated: {}
 ---

--- a/tests/install-normal.expected.yaml
+++ b/tests/install-normal.expected.yaml
@@ -41,6 +41,8 @@ spec:
           value: install
         - name: global.hubClusterDomain
           value: apps.hub.example.com
+        - name: global.clusterVersion
+          value: ""
   syncPolicy:
     automated: {}
 ---

--- a/tests/install.expected.diff
+++ b/tests/install.expected.diff
@@ -32,10 +32,10 @@
          - name: global.hubClusterDomain
 -          value: 
 +          value: apps.hub.example.com
+         - name: global.clusterVersion
+           value: ""
    syncPolicy:
-     automated: {}
- ---
-@@ -61,4 +61,4 @@
+@@ -63,4 +63,4 @@
    config:
      env:
        - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES


### PR DESCRIPTION
We add global.clusterVersion variable (OCP major.minor) and pass it on.
Then we add a /values-<global.clusterVersion.yaml> in the helm parameter
list.

This will allow us to have per-ocp version overrides and potentially
avoid having to use git branches more than needed.

Tested on MCG (w/ACM) and observed the correct global.clusterVersion
on both argo instances on hub and spoke. Also the new values includes
looked correct.
