### PR TITLE
Tweak the SSH paths so ssh-agent works again

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -4,12 +4,6 @@ if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/hybridcloudpatterns-utility-ee"
 fi
 
-# This is one of the most concise ways to get a readlink -f command work without going too complicated
-# Across Linux and MacOSX
-function real_path() {
-       echo $(cd $(dirname $1) ; pwd -P)
-}
-
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # /home/runner is the normal homedir
 # $HOME is mounted as itself for any files that are referenced with absolute paths
@@ -17,7 +11,7 @@ function real_path() {
 # We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
 SSH_SOCK_MOUNTS=""
 if [ -n "$SSH_AUTH_SOCK" ]; then
-	SSH_SOCK_MOUNTS="-v $(real_path $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+	SSH_SOCK_MOUNTS="-v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK} -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK}"
 fi
 
 podman run -it \


### PR DESCRIPTION
Newer ssh versions (worked for me in F36, broke in F37) seem to dislike
if the ssh-agent socket is in /ssh-agent in the container. The ssh-agent
on will just refuse the connections from the container.

Let's bind the original host path in the same place in the container.
That way we can also drop the real_path function().

Tested and now ssh agent correctly works again.
