### PR TITLE
Get the correct pattern name when the path has a folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME=$(shell basename `pwd`)
+NAME=$(shell basename "`pwd`")
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
 # This is because we expect to use tokens for repo authentication as opposed to SSH keys
 ifneq ($(origin TARGET_SITE), undefined)


### PR DESCRIPTION
Spotted by Jonny.

Before:
~/test me/multicloud-gitops -> NAME=$(shell basename "`pwd`") -> "test"

After:
~/test me/multicloud-gitops -> NAME=$(shell basename "`pwd`") -> "multicloud-gitops"
