### PR TITLE
Force targetRevision to be always a string

### DIFF
--- a/install/templates/argocd/application.yaml
+++ b/install/templates/argocd/application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: {{ .Values.main.git.repoURL }}
-    targetRevision: {{ .Values.main.git.revision }}
+    targetRevision: {{ .Values.main.git.revision | quote }}
     path: common/clustergroup
     helm:
       ignoreMissingValueFiles: true

--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -7,6 +7,6 @@ spec:
   clusterGroupName: {{ .Values.main.clusterGroupName }}
   gitSpec:
     targetRepo: {{ .Values.main.git.repoURL }}
-    targetRevision: {{ .Values.main.git.revision }}
+    targetRevision: {{ .Values.main.git.revision | quote }}
   gitOpsSpec:
     operatorChannel: {{ default "stable" .Values.main.gitops.channel }}

--- a/tests/install-naked.expected.yaml
+++ b/tests/install-naked.expected.yaml
@@ -22,7 +22,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/pattern-clone/mypattern
-    targetRevision: main
+    targetRevision: "main"
     path: common/clustergroup
     helm:
       ignoreMissingValueFiles: true

--- a/tests/install-normal.expected.yaml
+++ b/tests/install-normal.expected.yaml
@@ -22,7 +22,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/pattern-clone/mypattern
-    targetRevision: main
+    targetRevision: "main"
     path: common/clustergroup
     helm:
       ignoreMissingValueFiles: true

--- a/tests/operator-install-naked.expected.yaml
+++ b/tests/operator-install-naked.expected.yaml
@@ -9,7 +9,7 @@ spec:
   clusterGroupName: default
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
-    targetRevision: main
+    targetRevision: "main"
   gitOpsSpec:
     operatorChannel: stable
 ---

--- a/tests/operator-install-normal.expected.yaml
+++ b/tests/operator-install-normal.expected.yaml
@@ -9,7 +9,7 @@ spec:
   clusterGroupName: example
   gitSpec:
     targetRepo: https://github.com/pattern-clone/mypattern
-    targetRevision: main
+    targetRevision: "main"
   gitOpsSpec:
     operatorChannel: stable
 ---

--- a/tests/operator-install.expected.diff
+++ b/tests/operator-install.expected.diff
@@ -8,4 +8,4 @@
 +  clusterGroupName: example
    gitSpec:
      targetRepo: https://github.com/pattern-clone/mypattern
-     targetRevision: main
+     targetRevision: "main"


### PR DESCRIPTION
Jonny had a branch called '410' and the installation broke like this:

    $ make install
    make -f common/Makefile operator-deploy
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Checking repo https://github.com/mbaldessari/multicloud-gitops.git - branch 410
    https://github.com/mbaldessari/multicloud-gitops.git - 410 exists
    helm upgrade --install multicloud-gitops common/operator-install/ -f values-global.yaml --set main.git.repoURL="https://github.com/mbaldessari/multicloud-gitops.git" --set main.git.revision=410 --set global.hubClusterDomain=apps.mcg-hub.blueprints.rhecoeng.com
    Release "multicloud-gitops" does not exist. Installing it now.
    Error: Pattern.gitops.hybrid-cloud-patterns.io "multicloud-gitops" is invalid: spec.gitSpec.targetRevision: Invalid value: "integer": spec.gitSpec.targetRevision in body must be of type string: "integer"
    make[1]: *** [common/Makefile:70: operator-deploy] Error 1
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    make: *** [Makefile:10: operator-deploy] Error 2

Make sure we always quote the targetRevision.
Tested and it fixed the deployment with a numeric-only branch
