### PR TITLE
Add possibility to retry commands in run_command()

### DIFF
--- a/ansible/tests/unit/test_vault_load_secrets.py
+++ b/ansible/tests/unit/test_vault_load_secrets.py
@@ -117,10 +117,12 @@ class TestMyModule(unittest.TestCase):
 
         calls = [
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='VALUE'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='VALUE'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/aws' access_key_id='VALUE' secret_access_key='VALUE'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/aws' access_key_id='VALUE' secret_access_key='VALUE'\"",  # noqa: E501
+                attempts=3,
             ),
         ]
         mock_run_command.assert_has_calls(calls)
@@ -163,7 +165,8 @@ class TestMyModule(unittest.TestCase):
 
         calls = [
             call(
-                "cat '/home/michele/.ssh/id_rsa.pub' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/publickey b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
+                "cat '/home/michele/.ssh/id_rsa.pub' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/publickey b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
+                attempts=3,
             ),
         ]
         mock_run_command.assert_has_calls(calls)
@@ -188,31 +191,40 @@ class TestMyModule(unittest.TestCase):
 
         calls = [
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='demo123'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='demo123'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/googleapi' key='lskdjflskjdflsdjflsdkjfldsjkfldsj'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/googleapi' key='lskdjflskjdflsdjflsdkjfldsjkfldsj'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/cluster_alejandro' name='alejandro' bearerToken='sha256~bumxi-012345678901233455675678678098-abcdef'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/cluster_alejandro' name='alejandro' bearerToken='sha256~bumxi-012345678901233455675678678098-abcdef'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test' s3.accessKey='1234' s3.secretKey='4321' s3Secret='czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ=='\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test' s3.accessKey='1234' s3.secretKey='4321' s3Secret='czMuYWNjZXNzS2V5OiAxMjM0CnMzLnNlY3JldEtleTogNDMyMQ=='\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test2' s3.accessKey='accessKey' s3.secretKey='secretKey' s3Secret='fooo'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test2' s3.accessKey='accessKey' s3.secretKey='secretKey' s3Secret='fooo'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test3' s3.accessKey='aaaaa' s3.secretKey='bbbbbbbb' s3Secret='czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/test3' s3.accessKey='aaaaa' s3.secretKey='bbbbbbbb' s3Secret='czMuYWNjZXNzS2V5OiBhYWFhYQpzMy5zZWNyZXRLZXk6IGJiYmJiYmJi'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/region-one/config-demo' secret='region123'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/region-one/config-demo' secret='region123'\"",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/hub/cluster_alejandro_ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
+                attempts=3,
             ),
             call(
-                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'"  # noqa: E501
+                "cat '/home/michele/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put secret/region-one/ca b64content=- content=@/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
+                attempts=3,
             ),
         ]
         mock_run_command.assert_has_calls(calls)
@@ -242,7 +254,8 @@ class TestMyModule(unittest.TestCase):
 
         calls = [
             call(
-                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='VALUE' additionalsecret='test'\""  # noqa: E501
+                "oc exec -n vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/config-demo' secret='VALUE' additionalsecret='test'\"",  # noqa: E501
+                attempts=3,
             ),
         ]
         mock_run_command.assert_has_calls(calls)


### PR DESCRIPTION
Lester reported one issue with the following backtrace:

    TASK [vault_utils : Loads secrets file into the vault of a cluster]
    ***********************************************************************
    An exception occurred during task execution. To see the full
    traceback, use -vvv. The error was: subprocess.CalledProcessError:
    Command 'oc exec -n vault vault-0 -i -- sh -c "vault kv put
    'secret/hub/aws'
    s3Secret='...'"'
    returned non-zero exit status 1. fatal: [localhost]: FAILED! =>
    {"changed": false, "module_stderr": "Traceback (most recent call
    last):\n  File
    \"/home/claudiol/.ansible/tmp/ansible-tmp-1666041131.290091-69234-174948554391046/AnsiballZ_vault_load_secrets.py\",
    line 107, in <module>\n    _ansiballz_main()\n  File
    \"/home/claudiol/.ansible/tmp/ansible-tmp-1666041131.290091-69234-174948554391046/AnsiballZ_vault_load_secrets.py\",
    line 99, in _ansiballz_main\n    invoke_module(zipped_mod,
    temp_path, ANSIBALLZ_PARAMS)\n  File
    \"/home/claudiol/.ansible/tmp/ansible-tmp-1666041131.290091-69234-174948554391046/AnsiballZ_vault_load_secrets.py\",
    line 47, in invoke_module\n
    runpy.run_module(mod_name='ansible.modules.vault_load_secrets',
    init_globals=dict(_module_fqn='ansible.modules.vault_load_secrets',
    _modlib_path=modlib_path),\n  File
    \"/usr/lib64/python3.10/runpy.py\", line 224, in run_module\n
    return _run_module_code(code, init_globals, run_name, mod_spec)\n
    File \"/usr/lib64/python3.10/runpy.py\", line 96, in
    _run_module_code\n    _run_code(code, mod_globals, init_globals,\n
    File \"/usr/lib64/python3.10/runpy.py\", line 86, in _run_code\n
    exec(code, run_globals)\n  File
    \"/tmp/ansible_vault_load_secrets_payload_pwl_wc6j/ansible_vault_load_secrets_payload.zip/ansible/modules/vault_load_secrets.py\",
    line 462, in <module>\n  File
    \"/tmp/ansible_vault_load_secrets_payload_pwl_wc6j/ansible_vault_load_secrets_payload.zip/ansible/modules/vault_load_secrets.py\",
    line 458, in main\n  File
    \"/tmp/ansible_vault_load_secrets_payload_pwl_wc6j/ansible_vault_load_secrets_payload.zip/ansible/modules/vault_load_secrets.py\",
    line 445, in run\n  File
    \"/tmp/ansible_vault_load_secrets_payload_pwl_wc6j/ansible_vault_load_secrets_payload.zip/ansible/modules/vault_load_secrets.py\",
    line 369, in inject_secrets\n  File
    \"/tmp/ansible_vault_load_secrets_payload_pwl_wc6j/ansible_vault_load_secrets_payload.zip/ansible/modules/vault_load_secrets.py\",
    line 165, in run_command\n  File
    \"/usr/lib64/python3.10/subprocess.py\", line 524, in run\n    raise
    CalledProcessError(retcode,
    process.args,\nsubprocess.CalledProcessError: Command 'oc exec -n
    vault vault-0 -i -- sh -c \"vault kv put 'secret/hub/aws'
    s3Secret='...'\"'
    returned non-zero exit status 1.\n", "module_stdout": "", "msg":
    "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

This most likely is caused by a vault hiccup (a retry in this case
worked just fine). Let's add an attempts=1 and sleep=3 default values to
run_command() and set the attempts to three when running oc commands to
inject secrets in the vault.
