### PR TITLE
Symlink .github/linters/.gitleaks.toml to .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,1 @@
+.github/linters/.gitleaks.toml


### PR DESCRIPTION
This way splunk that runs on our repos won't barf on the
example secrets in our unit tests.
Use a symlink so we maintain a single copy of that file.
