### PR TITLE
Lower case cluster names in values-example.yaml

### DIFF
--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -76,7 +76,7 @@ clusterGroup:
           aws:
             region: ap-southeast-2
         clusters:
-        - One
+        - one
       exampleAzurePool:
         name: azure-us
         openshiftVersion: 4.10.18
@@ -86,8 +86,8 @@ clusterGroup:
             baseDomainResourceGroupName: dojo-dns-zones
             region: eastus
         clusters:
-        - Two
-        - Three
+        - two
+        - three
     acmlabels:
     - name: clusterGroup
       value: region

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -23,12 +23,12 @@ type: Opaque
 apiVersion: hive.openshift.io/v1
 kind: ClusterClaim
 metadata:
-  name: 'One-acm-provision-edge'
+  name: 'one-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
-    clusterClaimName: One-acm-provision-edge
+    clusterClaimName: one-acm-provision-edge
     clusterGroup: region
 spec:
   clusterPoolName: aws-ap
@@ -37,12 +37,12 @@ spec:
 apiVersion: hive.openshift.io/v1
 kind: ClusterClaim
 metadata:
-  name: 'Two-acm-provision-edge'
+  name: 'two-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
-    clusterClaimName: Two-acm-provision-edge
+    clusterClaimName: two-acm-provision-edge
     clusterGroup: region
 spec:
   clusterPoolName: azure-us
@@ -51,12 +51,12 @@ spec:
 apiVersion: hive.openshift.io/v1
 kind: ClusterClaim
 metadata:
-  name: 'Three-acm-provision-edge'
+  name: 'three-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
-    clusterClaimName: Three-acm-provision-edge
+    clusterClaimName: three-acm-provision-edge
     clusterGroup: region
 spec:
   clusterPoolName: azure-us

--- a/tests/acm.expected.diff
+++ b/tests/acm.expected.diff
@@ -28,12 +28,12 @@
 +apiVersion: hive.openshift.io/v1
 +kind: ClusterClaim
 +metadata:
-+  name: 'One-acm-provision-edge'
++  name: 'one-acm-provision-edge'
 +  annotations:
 +    argocd.argoproj.io/sync-wave: "20"
 +    cluster.open-cluster-management.io/createmanagedcluster: "true"
 +  labels:
-+    clusterClaimName: One-acm-provision-edge
++    clusterClaimName: one-acm-provision-edge
 +    clusterGroup: region
 +spec:
 +  clusterPoolName: aws-ap
@@ -42,12 +42,12 @@
 +apiVersion: hive.openshift.io/v1
 +kind: ClusterClaim
 +metadata:
-+  name: 'Two-acm-provision-edge'
++  name: 'two-acm-provision-edge'
 +  annotations:
 +    argocd.argoproj.io/sync-wave: "20"
 +    cluster.open-cluster-management.io/createmanagedcluster: "true"
 +  labels:
-+    clusterClaimName: Two-acm-provision-edge
++    clusterClaimName: two-acm-provision-edge
 +    clusterGroup: region
 +spec:
 +  clusterPoolName: azure-us
@@ -56,12 +56,12 @@
 +apiVersion: hive.openshift.io/v1
 +kind: ClusterClaim
 +metadata:
-+  name: 'Three-acm-provision-edge'
++  name: 'three-acm-provision-edge'
 +  annotations:
 +    argocd.argoproj.io/sync-wave: "20"
 +    cluster.open-cluster-management.io/createmanagedcluster: "true"
 +  labels:
-+    clusterClaimName: Three-acm-provision-edge
++    clusterClaimName: three-acm-provision-edge
 +    clusterGroup: region
 +spec:
 +  clusterPoolName: azure-us

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -111,7 +111,7 @@ data:
           exampleAWSPool:
             baseDomain: blueprints.rhecoeng.com
             clusters:
-            - One
+            - one
             name: aws-ap
             openshiftVersion: 4.10.18
             platform:
@@ -121,8 +121,8 @@ data:
           exampleAzurePool:
             baseDomain: blueprints.rhecoeng.com
             clusters:
-            - Two
-            - Three
+            - two
+            - three
             name: azure-us
             openshiftVersion: 4.10.18
             platform:

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -116,7 +116,7 @@
 +          exampleAWSPool:
 +            baseDomain: blueprints.rhecoeng.com
 +            clusters:
-+            - One
++            - one
 +            name: aws-ap
 +            openshiftVersion: 4.10.18
 +            platform:
@@ -126,8 +126,8 @@
 +          exampleAzurePool:
 +            baseDomain: blueprints.rhecoeng.com
 +            clusters:
-+            - Two
-+            - Three
++            - two
++            - three
 +            name: azure-us
 +            openshiftVersion: 4.10.18
 +            platform:


### PR DESCRIPTION
This will get rid of the following warning:
```
make helmlint
make -f common/Makefile helmlint
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
==> Linting common/acm
[INFO] Chart.yaml: icon is recommended
[WARNING] templates/provision/clusterpool.yaml: object name does not conform to Kubernetes naming requirements: "One-acm-provision-edge": metadata.name: Invalid value: "One-acm-provision-edge": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
[WARNING] templates/provision/clusterpool.yaml: object name does not conform to Kubernetes naming requirements: "Two-acm-provision-edge": metadata.name: Invalid value: "Two-acm-provision-edge": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
[WARNING] templates/provision/clusterpool.yaml: object name does not conform to Kubernetes naming requirements: "Three-acm-provision-edge": metadata.name: Invalid value: "Three-acm-provision-edge": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```
