### PR TITLE
Use UBI based images for ESO

### DIFF
--- a/golang-external-secrets/README.md
+++ b/golang-external-secrets/README.md
@@ -1,0 +1,5 @@
+# Subchart Update
+
+When updating this sub-chart, please remember to tweak the image tag in values.yaml.
+That is because we want to use -ubi images if possible and there is no suffix option, so
+we just override the tag with the version + "-ubi"

--- a/golang-external-secrets/values.yaml
+++ b/golang-external-secrets/values.yaml
@@ -4,3 +4,13 @@ mountRole: "hub-role"
 
 global:
   hubClusterDomain: hub.example.com
+
+external-secrets:
+  image:
+    tag: v0.6.0-ubi
+  webhook:
+    image:
+      tag: v0.6.0-ubi
+  certController:
+    image:
+      tag: v0.6.0-ubi

--- a/tests/golang-external-secrets-naked.expected.yaml
+++ b/tests/golang-external-secrets-naked.expected.yaml
@@ -6126,7 +6126,7 @@ spec:
       serviceAccountName: external-secrets-cert-controller
       containers:
         - name: cert-controller
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - certcontroller
@@ -6173,7 +6173,7 @@ spec:
       serviceAccountName: golang-external-secrets
       containers:
         - name: external-secrets
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - --concurrent=1
@@ -6210,7 +6210,7 @@ spec:
       serviceAccountName: external-secrets-webhook
       containers:
         - name: webhook
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - webhook

--- a/tests/golang-external-secrets-normal.expected.yaml
+++ b/tests/golang-external-secrets-normal.expected.yaml
@@ -6126,7 +6126,7 @@ spec:
       serviceAccountName: external-secrets-cert-controller
       containers:
         - name: cert-controller
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - certcontroller
@@ -6173,7 +6173,7 @@ spec:
       serviceAccountName: golang-external-secrets
       containers:
         - name: external-secrets
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - --concurrent=1
@@ -6210,7 +6210,7 @@ spec:
       serviceAccountName: external-secrets-webhook
       containers:
         - name: webhook
-          image: "ghcr.io/external-secrets/external-secrets:v0.6.0"
+          image: "ghcr.io/external-secrets/external-secrets:v0.6.0-ubi"
           imagePullPolicy: IfNotPresent
           args:
           - webhook


### PR DESCRIPTION
Thsi changes switches to use UBI based images as reccomended by
Matthias.

Tested on MCG on hub and also checked the regional cluster is still
working correctly:

    oc get -n golang-external-secrets pods -o yaml |grep -i image:
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi
	  image: ghcr.io/external-secrets/external-secrets:v0.6.0-ubi

Note that after this change, when we update the ESO subchart we also
need to tweak the version. That is why I added a README with the
reminder.
