### PR TITLE
Use no_log: true in any sensitive place

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -39,6 +39,7 @@
     secret_template: "{{ pattern_dir }}/values-secret.yaml.template"
 
 - name: Loads secrets file into the vault of a cluster
+  no_log: true
   vault_load_secrets:
     values_secrets: ~/values-secret.yaml
     check_missing_secrets: false

--- a/ansible/roles/vault_utils/tasks/vault_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_init.yaml
@@ -37,6 +37,7 @@
 # We need to retry here because the vault service might be starting
 # and can return a 500 internal server until its state is fully ready
 - name: Init vault operator
+  no_log: true
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
@@ -48,6 +49,7 @@
   when: not vault_initialized
 
 - name: Set vault init output json fact
+  no_log: true
   ansible.builtin.set_fact:
     vault_init_json: "{{ vault_init_json_out.stdout | from_json }}"
   when: not vault_initialized
@@ -56,6 +58,7 @@
 # the vault was not already initialized *and* when unseal_from_cluster
 # is set to false
 - name: Save vault operator output (local file)
+  no_log: true
   ansible.builtin.copy:
     follow: true
     dest: "{{ output_file_abs }}"
@@ -69,6 +72,7 @@
 # the cluster when the vault was not already initialized *and* when
 # unseal_from_cluster is set to true
 - name: Save vault operator output (into a secret inside the cluster)
+  no_log: true
   kubernetes.core.k8s:
     state: present
     definition:

--- a/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -34,6 +34,7 @@
   when: kubernetes_enabled.rc != 0
 
 - name: Get token from service account secret {{ external_secrets_ns }}/{{ external_secrets_secret }}
+  no_log: true
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
@@ -43,10 +44,12 @@
   failed_when: token_data.resources | length == 0
 
 - name: Set sa_token fact
+  no_log: true
   ansible.builtin.set_fact:
     sa_token: "{{ token_data.resources[0].data.token | b64decode }}"
 
 - name: Configure hub kubernetes backend
+  no_log: true
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"


### PR DESCRIPTION
Let's lower the risk of leaking any secrets by adding no_log: true to
any task that might be managing secrets/tokens or the likes.

Tested via MCG and correctly deployed it.
