### PR TITLE
Disable VALIDATE_DOCKERFILE_HADOLINT VALIDATE_TEKTON by default in common/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,15 @@ load-secrets: ## loads the secrets into the vault
 	common/scripts/vault-utils.sh push_secrets common/pattern-vault.init
 
 super-linter: ## Runs super linter locally
+	rm -rf .mypy_cache
 	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
 					-e VALIDATE_BASH=false \
 					-e VALIDATE_JSCPD=false \
 					-e VALIDATE_KUBERNETES_KUBEVAL=false \
 					-e VALIDATE_YAML=false \
 					-e VALIDATE_ANSIBLE=false \
+					-e VALIDATE_DOCKERFILE_HADOLINT=false \
+					-e VALIDATE_TEKTON=false \
 					$(DISABLE_LINTERS) \
 					-v $(PWD):/tmp/lint:rw,z docker.io/github/super-linter:slim-v4
 


### PR DESCRIPTION
By adding the following:

  -e VALIDATE_DOCKERFILE_HADOLINT=false \
  -e VALIDATE_TEKTON=false \

we can drop the custom super-linter target in most patterns. If there is
a pattern that needs to enable those it can update the super-linter
target in its top-level Makefile.

Also remove the .mypy_cache folder as it gets generated by super-linter
and then ends up being scanned as well which is inefficient.
