### PR TITLE
Make sure we can parse FQDNs after a secrets tag in values-secrets.yaml

### DIFF
--- a/ansible/plugins/modules/vault_load_secrets.py
+++ b/ansible/plugins/modules/vault_load_secrets.py
@@ -332,7 +332,7 @@ def get_secrets_vault_paths(module, syaml, keyname):
             continue
 
         # We are in the presence of either 'secrets.region-one' or 'files.cluster1' top-level keys
-        tmp = key.split(".")
+        tmp = key.split(".", 1)
         if len(tmp) != 2:
             module.fail_json(f"values-secrets.yaml key is non-conformant: {key}")
 

--- a/ansible/tests/unit/values-secret-fqdn.yaml
+++ b/ansible/tests/unit/values-secret-fqdn.yaml
@@ -1,0 +1,11 @@
+---
+secrets:
+  test:
+    secret1: foo
+
+secrets.region-one.blueprints.rhecoeng.com:
+  config-demo:
+    secret: region123
+
+files.region-one:
+  ca: /home/michele/ca.crt


### PR DESCRIPTION
If we have a values-secrets.yaml like the following:
secrets.region-one.blueprints.rhecoeng.com:
  foo:
    secret1: bar

This currently breaks as we split all dots. Only split the first dot
after secrets. So this example can work.

Also add a test case to cover for this.
