### PR TITLE
Add support for /values-<platform>-<clustergroup>.yaml

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## November 6, 2022
+
+* Add support for /values-<CloudPlatform>-<clusterGroup>.yaml (e.g. /values-AWS-group-one.yaml)
+
 ## October 28, 2022
 
 * Updated vault helm chart to v0.22.1 and vault containers to 1.12.0

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -45,6 +45,7 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
+                      - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}-{{ .name }}.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
                       - '/values-{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}-{{ .name }}.yaml'
@@ -70,6 +71,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}'
+                      - name: global.clusterPlatform
+                        value: {{ $.Values.global.clusterPlatform }}
                       - name: clusterGroup.name
                         value: {{ $group.name }}
                      {{- range .helmOverrides }}

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ $.Values.global.clusterDomain }}
             - name: global.clusterVersion
               value: "{{ $.Values.global.clusterVersion }}"
+            - name: global.clusterPlatform
+              value: "{{ $.Values.global.clusterPlatform }}"
             - name: global.hubClusterDomain
               value: {{ $.Values.global.hubClusterDomain }}
             - name: global.localClusterDomain
@@ -149,6 +151,9 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- if $.Values.global.clusterPlatform }}
+      - "/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- end }}
       {{- if $.Values.global.clusterVersion }}
       - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
       {{- end }}
@@ -169,6 +174,8 @@ spec:
           value: {{ $.Values.global.clusterDomain }}
         - name: global.clusterVersion
           value: "{{ $.Values.global.clusterVersion }}"
+        - name: global.clusterPlatform
+          value: "{{ $.Values.global.clusterPlatform }}"
         - name: global.hubClusterDomain
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -527,6 +527,7 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
                       - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-edge.yaml'
@@ -549,6 +550,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.clusterPlatform
+                        value: 
                       - name: clusterGroup.name
                         value: acm-edge
                       - name: clusterGroup.isHubCluster
@@ -614,6 +617,7 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
                       - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-provision-edge.yaml'
@@ -636,6 +640,8 @@ spec:
                       # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
                       - name: global.clusterVersion
                         value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
+                      - name: global.clusterPlatform
+                        value: 
                       - name: clusterGroup.name
                         value: acm-provision-edge
                       - name: clusterGroup.isHubCluster

--- a/tests/acm.expected.diff
+++ b/tests/acm.expected.diff
@@ -461,7 +461,7 @@
  # Source: acm/templates/policies/ocp-gitops-policy.yaml
  apiVersion: apps.open-cluster-management.io/v1
  kind: PlacementRule
-@@ -44,6 +482,181 @@
+@@ -44,6 +482,187 @@
          values:
            - OpenShift
  ---
@@ -510,6 +510,7 @@
 +                      valueFiles:
 +                      - "/values-global.yaml"
 +                      - "/values-acm-edge.yaml"
++                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
 +                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
 +                      # hub's cluster version, whereas we want to include the spoke cluster version
 +                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-edge.yaml'
@@ -532,6 +533,8 @@
 +                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
 +                      - name: global.clusterVersion
 +                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
++                      - name: global.clusterPlatform
++                        value: 
 +                      - name: clusterGroup.name
 +                        value: acm-edge
 +                      - name: clusterGroup.isHubCluster
@@ -597,6 +600,7 @@
 +                      valueFiles:
 +                      - "/values-global.yaml"
 +                      - "/values-acm-provision-edge.yaml"
++                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
 +                      # We cannot use $.Values.global.clusterVersion because that gets resolved to the
 +                      # hub's cluster version, whereas we want to include the spoke cluster version
 +                      - '/values-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}-acm-provision-edge.yaml'
@@ -619,6 +623,8 @@
 +                      # Requires ACM 2.6 or higher (I could not come up with something less terrible to get maj.min)
 +                      - name: global.clusterVersion
 +                        value: '{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}'
++                      - name: global.clusterPlatform
++                        value: 
 +                      - name: clusterGroup.name
 +                        value: acm-provision-edge
 +                      - name: clusterGroup.isHubCluster

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -528,6 +528,8 @@ spec:
           value: region.example.com
         - name: global.clusterVersion
           value: ""
+        - name: global.clusterPlatform
+          value: ""
         - name: global.hubClusterDomain
           value: apps.hub.example.com
         - name: global.localClusterDomain
@@ -580,6 +582,8 @@ spec:
         - name: global.clusterDomain
           value: region.example.com
         - name: global.clusterVersion
+          value: ""
+        - name: global.clusterPlatform
           value: ""
         - name: global.hubClusterDomain
           value: apps.hub.example.com

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -239,7 +239,7 @@
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -45,16 +255,587 @@
+@@ -45,16 +255,591 @@
    - kind: ServiceAccount
      # This is the {ArgoCD.name}-argocd-application-controller
      name: example-gitops-argocd-application-controller
@@ -519,6 +519,8 @@
 +          value: region.example.com
 +        - name: global.clusterVersion
 +          value: ""
++        - name: global.clusterPlatform
++          value: ""
 +        - name: global.hubClusterDomain
 +          value: apps.hub.example.com
 +        - name: global.localClusterDomain
@@ -571,6 +573,8 @@
 +        - name: global.clusterDomain
 +          value: region.example.com
 +        - name: global.clusterVersion
++          value: ""
++        - name: global.clusterPlatform
 +          value: ""
 +        - name: global.hubClusterDomain
 +          value: apps.hub.example.com
@@ -830,7 +834,7 @@
  ---
  # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
  apiVersion: argoproj.io/v1alpha1
-@@ -65,7 +846,7 @@
+@@ -65,7 +850,7 @@
    # Changing the name affects the ClusterRoleBinding, the generated secret,
    # route URL, and argocd.argoproj.io/managed-by annotations
    name: example-gitops
@@ -839,7 +843,7 @@
    annotations:
      argocd.argoproj.io/compare-options: IgnoreExtraneous
  spec:
-@@ -94,10 +875,10 @@
+@@ -94,10 +879,10 @@
              --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
              --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
              --set global.namespace=$ARGOCD_APP_NAMESPACE
@@ -854,7 +858,7 @@
              --set clusterGroup.name=example
              --post-renderer ./kustomize"]
    applicationSet:
-@@ -174,11 +955,59 @@
+@@ -174,11 +959,59 @@
  kind: ConsoleLink
  metadata:
    name: example-gitops-link


### PR DESCRIPTION
In the same vein as /values-<ocpversion>-<clustergroup>.yaml support, we
allow for clusterplatform overrides. Values files now look like the
following:
/values-global.yaml, /values-group-one.yaml, /values-AWS-group-one.yaml, /values-4.11-group-one.yaml

Tested with
https://github.com/hybrid-cloud-patterns/patterns-operator/pull/42 and
could get the correct /values file inclusion in cluster-wide argo and on
the namespaced-argo on both the hub and the spoke clusters.
