### PR TITLE
Drop insecureUnsealVaultInsideCluster

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,11 @@
 # Changes
 
+## December 9, 2022
+
+* Dropped insecureUnsealVaultInsideCluster (and file_unseal) entirely. Now
+  vault is always unsealed via a cronjob in the cluster. It is recommended to
+  store the imperative/vaultkeys secret offline securely and then delete it.
+
 ## December 8, 2022
 
 * Removed the legacy installation targets:

--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,6 @@ uninstall: ## runs helm uninstall
 	helm uninstall $(NAME)
 	@oc delete csv -n openshift-operators $(CSV)
 
-.PHONY: vault-init
-vault-init: ## inits, unseals and configured the vault
-	common/scripts/vault-utils.sh vault_init common/pattern-vault.init
-	common/scripts/vault-utils.sh vault_unseal common/pattern-vault.init
-	common/scripts/vault-utils.sh vault_secrets_init common/pattern-vault.init
-
-.PHONY: vault-unseal
-vault-unseal: ## unseals the vault
-	common/scripts/vault-utils.sh vault_unseal common/pattern-vault.init
-
 .PHONY: load-secrets
 load-secrets: ## loads the secrets into the vault
 	common/scripts/vault-utils.sh push_secrets common/pattern-vault.init $(NAME)
@@ -68,8 +58,7 @@ CHARTS=$(shell find . -type f -iname 'Chart.yaml' -exec dirname "{}"  \; | grep 
 TEST_OPTS= -f values-global.yaml --set global.repoURL="https://github.com/pattern-clone/mypattern" \
 	--set main.git.repoURL="https://github.com/pattern-clone/mypattern" --set main.git.revision=main --set global.pattern="mypattern" \
 	--set global.namespace="pattern-namespace" --set global.hubClusterDomain=apps.hub.example.com --set global.localClusterDomain=apps.region.example.com --set global.clusterDomain=region.example.com\
-	--set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml" \
-	--set clusterGroup.insecureUnsealVaultInsideCluster=true
+	--set "clusterGroup.imperative.jobs[0].name"="test" --set "clusterGroup.imperative.jobs[0].playbook"="ansible/test.yml"
 PATTERN_OPTS=-f common/examples/values-example.yaml
 EXECUTABLES=git helm oc ansible
 

--- a/ansible/roles/vault_utils/README.md
+++ b/ansible/roles/vault_utils/README.md
@@ -39,7 +39,6 @@ If set to false they will be stored inside a secret defined by `unseal_secret`
 in the `imperative` namespace:
 
 ```yaml
-file_unseal: true
 # token inside a secret in the cluster.
 # *Note* that this is fundamentally unsafe
 output_file: "common/pattern-vault.init"
@@ -218,11 +217,9 @@ Internals
 Here is the rough high-level algorithm used to unseal the vault:
 
 1. Check vault status. If vault is not initialized go to 2. If initialized go to 3.
-2. Initialize vault and store unseal keys + login token either on a local file
-   or inside a secret in k8s (file_unseal var controls this)
+2. Initialize vault and store unseal keys + login token inside a secret in k8s
 3. Check vault status. If vault is unsealed go to 5. else to to 4.
-4. Unseal the vault using the secrets read from the file or the secret
-   (file_unseal controls this)
+4. Unseal the vault using the secrets read from the k8s secret
 5. Configure the vault (should be idempotent)
 
 ## License

--- a/ansible/roles/vault_utils/defaults/main.yml
+++ b/ansible/roles/vault_utils/defaults/main.yml
@@ -18,9 +18,5 @@ output_file: "common/pattern-vault.init"
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
 external_secrets_secret: golang-external-secrets
-# Setting this to false makes the role store the vault unseal keys and root login
-# token inside a secret in the cluster.
-# *Note* that this is fundamentally unsafe
-file_unseal: true
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"

--- a/ansible/roles/vault_utils/tasks/vault_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_init.yaml
@@ -9,33 +9,6 @@
   ansible.builtin.set_fact:
     vault_initialized: "{{ vault_status['initialized'] | bool }}"
 
-# Note that the 'realpath' filter explicitely only resolves on the ansible/local box
-# which is fine in our case
-- name: Set absolute path for output_file
-  ansible.builtin.set_fact:
-    output_file_abs: "{{ output_file | realpath }}"
-  when:
-    - not vault_initialized
-    - file_unseal
-
-- name: Check for existence of "{{ output_file_abs }}"
-  ansible.builtin.stat:
-    path: "{{ output_file_abs }}"
-  register: result
-  when:
-    - not vault_initialized
-    - file_unseal
-
-- name: Rename "{{ output_file_abs }} if it exists"
-  ansible.builtin.copy:
-    src: "{{ output_file_abs }}"
-    dest: "{{ output_file_abs }}.bak"
-    mode: '0600'
-  when:
-    - not vault_initialized
-    - file_unseal
-    - result.stat.exists
-
 # We need to retry here because the vault service might be starting
 # and can return a 500 internal server until its state is fully ready
 - name: Init vault operator
@@ -56,20 +29,6 @@
     vault_init_json: "{{ vault_init_json_out.stdout | from_json }}"
   when: not vault_initialized
 
-# We store the the operator unseal keys and root token to a file when
-# the vault was not already initialized *and* when unseal_from_cluster
-# is set to false
-- name: Save vault operator output (local file)
-  no_log: true
-  ansible.builtin.copy:
-    follow: true
-    dest: "{{ output_file_abs }}"
-    content: "{{ vault_init_json | to_nice_json }}"
-    mode: '0600'
-  when:
-    - not vault_initialized
-    - file_unseal
-
 # We store the the operator unseal keys and root token to a secret inside
 # the cluster when the vault was not already initialized *and* when
 # unseal_from_cluster is set to true
@@ -88,4 +47,3 @@
         vault_data_json: "{{ vault_init_json | to_nice_json | b64encode }}"
   when:
     - not vault_initialized
-    - not file_unseal

--- a/ansible/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_unseal.yaml
@@ -9,43 +9,8 @@
   ansible.builtin.set_fact:
     vault_sealed: "{{ vault_status['sealed'] | bool }}"
 
-# Note that the 'realpath' filter explicitely only resolves on the ansible/local box
-# which is fine in our case
-- name: Set absolute path for output_file
-  ansible.builtin.set_fact:
-    output_file_abs: "{{ output_file | realpath }}"
-  when:
-    - vault_sealed
-    - file_unseal
-
-- name: Check for existence of "{{ output_file_abs }}"
-  ansible.builtin.stat:
-    path: "{{ output_file_abs }}"
-  register: result
-  when:
-    - vault_sealed
-    - file_unseal
-
-- name: Fail if "{{ output_file_abs }}" does not exists
-  ansible.builtin.fail:
-    msg: "{{ output_file_abs }} does not exist. Stopping here"
-  failed_when: not result.stat.exists
-  when:
-    - vault_sealed
-    - file_unseal
-
-# We reparse the json vault init file in case unseal was called without operator init before
-# and if file_unseal is true
-- name: Parse "{{ output_file_abs }}"
-  ansible.builtin.set_fact:
-    vault_init_json: "{{ lookup('file', output_file_abs) | from_json }}"
-  when:
-    - vault_sealed
-    - file_unseal
-
 # We reparse the json vault init secret in case unseal was called without operator init before
-# and if file_unseal is false
-- name: Parse "{{ output_file_abs }}"
+- name: Parse vaultkeys
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ unseal_namespace }}"
@@ -54,14 +19,21 @@
   register: vault_init_data
   when:
     - vault_sealed
-    - not file_unseal
+
+- name: Does the vaultkeys secret exist?
+  ansible.builtin.set_fact:
+    vaultkeys_exists: "{{ vault_init_data.resources | length > 0 }}"
+
+- name: Vaultkeys does not exist and the vault is sealed, so exit
+  ansible.builtin.meta: end_play
+  when:
+    - vault_sealed
+    - not vaultkeys_exists
 
 - name: Set vault init json
   ansible.builtin.set_fact:
     vault_init_json: "{{ vault_init_data.resources[0].data.vault_data_json | b64decode | from_json }}"
-  when:
-    - vault_sealed
-    - not file_unseal
+  when: vault_sealed
 
 - name: Set root token and unseal_keys
   ansible.builtin.set_fact:

--- a/clustergroup/templates/imperative/clusterrole.yaml
+++ b/clustergroup/templates/imperative/clusterrole.yaml
@@ -1,7 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -19,6 +17,5 @@ rules:
     - get
     - list
     - watch
-{{- end }}
 {{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/configmap.yaml
+++ b/clustergroup/templates/imperative/configmap.yaml
@@ -1,7 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 {{- $valuesyaml := toYaml $.Values -}}
 apiVersion: v1
 kind: ConfigMap
@@ -11,5 +9,4 @@ metadata:
 data:
   values.yaml: |
 {{ tpl $valuesyaml . | indent 4 }}
-{{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/namespace.yaml
+++ b/clustergroup/templates/imperative/namespace.yaml
@@ -1,7 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -9,5 +7,4 @@ metadata:
     name: {{ $.Values.clusterGroup.imperative.namespace }}
     argocd.argoproj.io/managed-by: {{ $.Values.global.pattern }}-{{ $.Values.clusterGroup.name }}
   name: {{ $.Values.clusterGroup.imperative.namespace }}
-{{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/rbac.yaml
+++ b/clustergroup/templates/imperative/rbac.yaml
@@ -1,7 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -29,5 +27,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
     namespace: {{ $.Values.clusterGroup.imperative.namespace }}
-{{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/role.yaml
+++ b/clustergroup/templates/imperative/role.yaml
@@ -1,7 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -18,6 +16,5 @@ rules:
     - '*'
     verbs:
     - '*'
-{{- end }}
 {{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/serviceaccount.yaml
+++ b/clustergroup/templates/imperative/serviceaccount.yaml
@@ -1,13 +1,10 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Define this if needed (jobs defined or insecure unseal configured) */}}
-{{- if or (gt (len $.Values.clusterGroup.imperative.jobs) 0)
-    (and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster) -}}
+{{/* This is always defined as we always unseal the cluster with an imperative job */}}
 {{- if $.Values.clusterGroup.imperative.serviceAccountCreate -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
   namespace: {{ $.Values.clusterGroup.imperative.namespace }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -1,6 +1,5 @@
 {{- if not (eq .Values.enabled "plumbing") }}
-{{/* Only define this if the values.insecureUnsealVaultInsideCluster is set to tre and we're on the cluster */}}
-{{- if and $.Values.clusterGroup.insecureUnsealVaultInsideCluster $.Values.clusterGroup.isHubCluster }}
+{{- if $.Values.clusterGroup.isHubCluster }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -41,8 +40,6 @@ spec:
                 {{- end }}
                 - -e
                 - "@/values/values.yaml"
-                - -e
-                - '{"file_unseal": false}'
                 - -t
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"

--- a/clustergroup/test.yaml
+++ b/clustergroup/test.yaml
@@ -1,9 +1,6 @@
 clusterGroup:
   name: hub
   isHubCluster: true
-  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
-  # is fundamentally insecure
-  insecureUnsealVaultInsideCluster: false
 
   namespaces:
   - open-cluster-management

--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -13,9 +13,6 @@ clusterGroup:
   name: example
   isHubCluster: true
   targetCluster: in-cluster
-  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
-  # is fundamentally insecure
-  insecureUnsealVaultInsideCluster: false
 
   imperative:
     jobs: []

--- a/examples/industrial-edge-hub.yaml
+++ b/examples/industrial-edge-hub.yaml
@@ -1,9 +1,6 @@
 clusterGroup:
   name: datacenter
   isHubCluster: true
-  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
-  # is fundamentally insecure
-  insecureUnsealVaultInsideCluster: true
 
   namespaces:
   - golang-external-secrets

--- a/examples/medical-diagnosis-hub.yaml
+++ b/examples/medical-diagnosis-hub.yaml
@@ -1,9 +1,6 @@
 clusterGroup:
   name: hub
   isHubCluster: true
-  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
-  # is fundamentally insecure
-  insecureUnsealVaultInsideCluster: true
 
   namespaces:
   - open-cluster-management

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -103,7 +103,6 @@ data:
         serviceAccountName: imperative-sa
         valuesConfigMap: helm-values-configmap
         verbosity: ""
-      insecureUnsealVaultInsideCluster: true
       isHubCluster: false
       name: factory
       namespaces:

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -224,7 +224,6 @@ data:
         serviceAccountName: imperative-sa
         valuesConfigMap: helm-values-configmap
         verbosity: ""
-      insecureUnsealVaultInsideCluster: true
       isHubCluster: true
       managedClusterGroups:
         factory:
@@ -549,8 +548,6 @@ spec:
                 - ansible-playbook
                 - -e
                 - "@/values/values.yaml"
-                - -e
-                - '{"file_unseal": false}'
                 - -t
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -236,7 +236,6 @@ data:
         serviceAccountName: imperative-sa
         valuesConfigMap: helm-values-configmap
         verbosity: ""
-      insecureUnsealVaultInsideCluster: true
       isHubCluster: true
       managedClusterGroups:
         region-one:
@@ -536,8 +535,6 @@ spec:
                 - ansible-playbook
                 - -e
                 - "@/values/values.yaml"
-                - -e
-                - '{"file_unseal": false}'
                 - -t
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -1,4 +1,13 @@
 ---
+# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: imperative
+    argocd.argoproj.io/managed-by: common-example
+  name: imperative
+---
 # Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
@@ -11,6 +20,86 @@ metadata:
   # - any references to secrets and route URLs in documentation
   name: common-example
 spec: {}
+---
+# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imperative-sa
+  namespace: imperative
+---
+# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-values-configmap-example
+  namespace: imperative
+data:
+  values.yaml: |
+    clusterGroup:
+      imperative:
+        activeDeadlineSeconds: 3600
+        clusterRoleName: imperative-cluster-role
+        clusterRoleYaml: ""
+        cronJobName: imperative-cronjob
+        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        imagePullPolicy: Always
+        insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
+        jobName: imperative-job
+        jobs: []
+        namespace: imperative
+        roleName: imperative-role
+        roleYaml: ""
+        schedule: '*/10 * * * *'
+        serviceAccountCreate: true
+        serviceAccountName: imperative-sa
+        valuesConfigMap: helm-values-configmap
+        verbosity: ""
+      isHubCluster: true
+      name: example
+      targetCluster: in-cluster
+    enabled: all
+    global:
+      options:
+        installPlanApproval: Automatic
+        syncPolicy: Automatic
+        useCSV: true
+      pattern: common
+      targetRevision: main
+    secretStore:
+      kind: ClusterSecretStore
+      name: vault-backend
+    secretsBase:
+      key: secret/data/hub
+---
+# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imperative-cluster-role
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - get
+    - list
+    - watch
+---
+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: imperative-cluster-admin-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: imperative-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: imperative-sa
+    namespace: imperative
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
@@ -55,6 +144,111 @@ subjects:
   - kind: ServiceAccount
     name: example-gitops-argocd-dex-server
     namespace: common-example
+---
+# Source: pattern-clustergroup/templates/imperative/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: imperative-role
+  namespace: imperative
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+---
+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: imperative-admin-rolebinding
+  namespace: imperative
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: imperative-role
+subjects:
+  - kind: ServiceAccount
+    name: imperative-sa
+    namespace: imperative
+---
+# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: unsealvault-cronjob
+  namespace: imperative
+spec:
+  schedule: "*/5 * * * *"
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: unsealvault-job
+        spec:
+          serviceAccountName: imperative-sa
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there            
+            - name: git-init
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch main --depth 1 --  /git/repo;chmod 0770 /git/{repo,home}"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+            - name: unseal-playbook
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - "600"
+                - ansible-playbook
+                - -e
+                - "@/values/values.yaml"
+                - -t
+                - 'vault_init,vault_unseal,vault_secrets_init'
+                - "common/ansible/playbooks/vault/vault.yaml"
+              volumeMounts:                
+                - name: git
+                  mountPath: "/git"
+                - name: values-volume
+                  mountPath: /values/values.yaml
+                  subPath: values.yaml
+          containers:            
+            - name: "done"
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              command:
+                - 'sh'
+                - '-c'
+                - 'echo'
+                - 'done'
+                - '\n'
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: helm-values-configmap-example
+          restartPolicy: Never
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -91,7 +91,6 @@ data:
         serviceAccountName: imperative-sa
         valuesConfigMap: helm-values-configmap
         verbosity: ""
-      insecureUnsealVaultInsideCluster: true
       isHubCluster: true
       managedClusterGroups:
       - acmlabels:
@@ -418,8 +417,6 @@ spec:
                 - ansible-playbook
                 - -e
                 - "@/values/values.yaml"
-                - -e
-                - '{"file_unseal": false}'
                 - -t
                 - 'vault_init,vault_unseal,vault_secrets_init'
                 - "common/ansible/playbooks/vault/vault.yaml"

--- a/tests/clustergroup.expected.diff
+++ b/tests/clustergroup.expected.diff
@@ -1,6 +1,6 @@
 --- tests/clustergroup-naked.expected.yaml
 +++ tests/clustergroup-normal.expected.yaml
-@@ -1,17 +1,227 @@
+@@ -1,11 +1,29 @@
  ---
 +# Source: pattern-clustergroup/templates/core/namespaces.yaml
 +apiVersion: v1
@@ -20,17 +20,18 @@
 +  name: application-ci
 +spec:
 +---
-+# Source: pattern-clustergroup/templates/imperative/namespace.yaml
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  labels:
-+    name: imperative
-+    argocd.argoproj.io/managed-by: mypattern-example
-+  name: imperative
-+---
- # Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+ # Source: pattern-clustergroup/templates/imperative/namespace.yaml
  apiVersion: v1
+ kind: Namespace
+ metadata:
+   labels:
+     name: imperative
+-    argocd.argoproj.io/managed-by: common-example
++    argocd.argoproj.io/managed-by: mypattern-example
+   name: imperative
+ ---
+ # Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+@@ -13,12 +31,12 @@
  kind: Namespace
  metadata:
    labels:
@@ -44,22 +45,11 @@
 +  name: mypattern-example
  spec: {}
  ---
-+# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
-+apiVersion: v1
-+kind: ServiceAccount
-+metadata:
-+  name: imperative-sa
-+  namespace: imperative
-+---
-+# Source: pattern-clustergroup/templates/imperative/configmap.yaml
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
-+  name: helm-values-configmap-example
-+  namespace: imperative
-+data:
-+  values.yaml: |
-+    clusterGroup:
+ # Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+@@ -37,6 +55,22 @@
+ data:
+   values.yaml: |
+     clusterGroup:
 +      applications:
 +        acm:
 +          ignoreDifferences:
@@ -76,28 +66,24 @@
 +          namespace: application-ci
 +          path: charts/datacenter/pipelines
 +          project: datacenter
-+      imperative:
-+        activeDeadlineSeconds: 3600
-+        clusterRoleName: imperative-cluster-role
-+        clusterRoleYaml: ""
-+        cronJobName: imperative-cronjob
-+        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
-+        imagePullPolicy: Always
-+        insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
-+        jobName: imperative-job
+       imperative:
+         activeDeadlineSeconds: 3600
+         clusterRoleName: imperative-cluster-role
+@@ -46,7 +80,9 @@
+         imagePullPolicy: Always
+         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
+         jobName: imperative-job
+-        jobs: []
 +        jobs:
 +        - name: test
 +          playbook: ansible/test.yml
-+        namespace: imperative
-+        roleName: imperative-role
-+        roleYaml: ""
-+        schedule: '*/10 * * * *'
-+        serviceAccountCreate: true
-+        serviceAccountName: imperative-sa
-+        valuesConfigMap: helm-values-configmap
-+        verbosity: ""
-+      insecureUnsealVaultInsideCluster: true
-+      isHubCluster: true
+         namespace: imperative
+         roleName: imperative-role
+         roleYaml: ""
+@@ -57,16 +93,100 @@
+         verbosity: ""
+       insecureUnsealVaultInsideCluster: true
+       isHubCluster: true
 +      managedClusterGroups:
 +      - acmlabels:
 +        - name: clusterGroup
@@ -148,7 +134,7 @@
 +        - domain: syd.beekhof.net
 +          name: sydney
 +        name: argo-edge
-+      name: example
+       name: example
 +      namespaces:
 +      - open-cluster-management
 +      - application-ci
@@ -168,9 +154,9 @@
 +        pipelines:
 +          csv: redhat-openshift-pipelines.v1.5.2
 +          name: openshift-pipelines-operator-rh
-+      targetCluster: in-cluster
-+    enabled: all
-+    global:
+       targetCluster: in-cluster
+     enabled: all
+     global:
 +      clusterDomain: region.example.com
 +      git:
 +        account: hybrid-cloud-patterns
@@ -180,57 +166,24 @@
 +      hubClusterDomain: apps.hub.example.com
 +      localClusterDomain: apps.region.example.com
 +      namespace: pattern-namespace
-+      options:
-+        installPlanApproval: Automatic
-+        syncPolicy: Automatic
+       options:
+         installPlanApproval: Automatic
+         syncPolicy: Automatic
+-        useCSV: true
+-      pattern: common
 +        useCSV: false
 +      pattern: mypattern
 +      repoURL: https://github.com/pattern-clone/mypattern
-+      targetRevision: main
+       targetRevision: main
 +    main:
 +      clusterGroupName: example
 +      git:
 +        repoURL: https://github.com/pattern-clone/mypattern
 +        revision: main
-+    secretStore:
-+      kind: ClusterSecretStore
-+      name: vault-backend
-+    secretsBase:
-+      key: secret/data/hub
-+---
-+# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRole
-+metadata:
-+  name: imperative-cluster-role
-+rules:
-+  - apiGroups:
-+    - '*'
-+    resources:
-+    - '*'
-+    verbs:
-+    - get
-+    - list
-+    - watch
-+---
-+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRoleBinding
-+metadata:
-+  name: imperative-cluster-admin-rolebinding
-+roleRef:
-+  apiGroup: rbac.authorization.k8s.io
-+  kind: ClusterRole
-+  name: imperative-cluster-role
-+subjects:
-+  - kind: ServiceAccount
-+    name: imperative-sa
-+    namespace: imperative
-+---
- # Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
- # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
- apiVersion: rbac.authorization.k8s.io/v1
-@@ -36,7 +246,7 @@
+     secretStore:
+       kind: ClusterSecretStore
+       name: vault-backend
+@@ -126,7 +246,7 @@
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
@@ -239,7 +192,7 @@
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -45,16 +255,591 @@
+@@ -135,16 +255,16 @@
    - kind: ServiceAccount
      # This is the {ArgoCD.name}-argocd-application-controller
      name: example-gitops-argocd-application-controller
@@ -256,36 +209,13 @@
      name: example-gitops-argocd-dex-server
 -    namespace: common-example
 +    namespace: mypattern-example
-+---
-+# Source: pattern-clustergroup/templates/imperative/role.yaml
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: Role
-+metadata:
-+  name: imperative-role
-+  namespace: imperative
-+rules:
-+  - apiGroups:
-+    - '*'
-+    resources:
-+    - '*'
-+    verbs:
-+    - '*'
-+---
-+# Source: pattern-clustergroup/templates/imperative/rbac.yaml
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: RoleBinding
-+metadata:
-+  name: imperative-admin-rolebinding
-+  namespace: imperative
-+roleRef:
-+  apiGroup: rbac.authorization.k8s.io
-+  kind: Role
-+  name: imperative-role
-+subjects:
-+  - kind: ServiceAccount
-+    name: imperative-sa
-+    namespace: imperative
-+---
+ ---
+ # Source: pattern-clustergroup/templates/imperative/role.yaml
+ apiVersion: rbac.authorization.k8s.io/v1
+@@ -175,6 +295,80 @@
+     name: imperative-sa
+     namespace: imperative
+ ---
 +# Source: pattern-clustergroup/templates/imperative/job.yaml
 +apiVersion: batch/v1
 +kind: CronJob
@@ -360,84 +290,22 @@
 +              name: helm-values-configmap-example
 +          restartPolicy: Never
 +---
-+# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
-+apiVersion: batch/v1
-+kind: CronJob
-+metadata:
-+  name: unsealvault-cronjob
-+  namespace: imperative
-+spec:
-+  schedule: "*/5 * * * *"
-+  # if previous Job is still running, skip execution of a new Job
-+  concurrencyPolicy: Forbid
-+  jobTemplate:
-+    spec:
-+      activeDeadlineSeconds: 3600
-+      template:
-+        metadata:
-+          name: unsealvault-job
-+        spec:
-+          serviceAccountName: imperative-sa
-+          initContainers:
-+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
-+            # reason for that is ansible refuses to create temporary folders in there            
-+            - name: git-init
-+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
-+              imagePullPolicy: Always
-+              env:
-+                - name: HOME
-+                  value: /git/home
-+              command:
-+              - 'sh'
-+              - '-c'
+ # Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+ apiVersion: batch/v1
+ kind: CronJob
+@@ -205,7 +399,7 @@
+               command:
+               - 'sh'
+               - '-c'
+-              - "mkdir /git/{repo,home};git clone --single-branch --branch main --depth 1 --  /git/repo;chmod 0770 /git/{repo,home}"
 +              - "mkdir /git/{repo,home};git clone --single-branch --branch main --depth 1 -- https://github.com/pattern-clone/mypattern /git/repo;chmod 0770 /git/{repo,home}"
-+              volumeMounts:
-+              - name: git
-+                mountPath: "/git"
-+            - name: unseal-playbook
-+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
-+              imagePullPolicy: Always
-+              env:
-+                - name: HOME
-+                  value: /git/home
-+              workingDir: /git/repo
-+              # We have a default timeout of 600s for each playbook. Can be overridden
-+              # on a per-job basis
-+              command:
-+                - timeout
-+                - "600"
-+                - ansible-playbook
-+                - -e
-+                - "@/values/values.yaml"
-+                - -e
-+                - '{"file_unseal": false}'
-+                - -t
-+                - 'vault_init,vault_unseal,vault_secrets_init'
-+                - "common/ansible/playbooks/vault/vault.yaml"
-+              volumeMounts:                
-+                - name: git
-+                  mountPath: "/git"
-+                - name: values-volume
-+                  mountPath: /values/values.yaml
-+                  subPath: values.yaml
-+          containers:            
-+            - name: "done"
-+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
-+              imagePullPolicy: Always
-+              command:
-+                - 'sh'
-+                - '-c'
-+                - 'echo'
-+                - 'done'
-+                - '\n'
-+          volumes:
-+          - name: git
-+            emptyDir: {}
-+          - name: values-volume
-+            configMap:
-+              name: helm-values-configmap-example
-+          restartPolicy: Never
-+---
+               volumeMounts:
+               - name: git
+                 mountPath: "/git"
+@@ -253,6 +447,400 @@
+               name: helm-values-configmap-example
+           restartPolicy: Never
+ ---
 +# Source: pattern-clustergroup/templates/core/subscriptions.yaml
 +---
 +---
@@ -831,10 +699,11 @@
 +    kind: Route
 +    jsonPointers:
 +    - /status
- ---
++---
  # Source: pattern-clustergroup/templates/plumbing/argocd.yaml
  apiVersion: argoproj.io/v1alpha1
-@@ -65,7 +850,7 @@
+ kind: ArgoCD
+@@ -262,7 +850,7 @@
    # Changing the name affects the ClusterRoleBinding, the generated secret,
    # route URL, and argocd.argoproj.io/managed-by annotations
    name: example-gitops
@@ -843,7 +712,7 @@
    annotations:
      argocd.argoproj.io/compare-options: IgnoreExtraneous
  spec:
-@@ -94,10 +879,10 @@
+@@ -291,10 +879,10 @@
              --set global.repoURL=$ARGOCD_APP_SOURCE_REPO_URL
              --set global.targetRevision=$ARGOCD_APP_SOURCE_TARGET_REVISION
              --set global.namespace=$ARGOCD_APP_NAMESPACE
@@ -858,7 +727,7 @@
              --set clusterGroup.name=example
              --post-renderer ./kustomize"]
    applicationSet:
-@@ -174,11 +959,59 @@
+@@ -371,11 +959,59 @@
  kind: ConsoleLink
  metadata:
    name: example-gitops-link


### PR DESCRIPTION
We always just unseal the vault from the cluster. We simply drop support
of running these commands manually entirely. The advantage is that the
code is a lot simpler and we have a single avenue to do things.

Tested as following:
1. Deployed MCG and observed loading of secrets happening correctly
2. Removed the imperative/vaultkeys secret
3. Deleted the vault-0 pod
4. Observed that the vault-0 pod was restarted and that the vault was
   sealed
5. Observed that the unsealvault cronjob did nothing
6. Restored the vaultkeys secret
7. Observed that the unsealvault cronjob unsealed the vault correctly
   again