### PR TITLE
Drop callbacks_enabled

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,4 +3,3 @@ display_skipped_hosts=False
 localhost_warning=False
 library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-callbacks_enabled = profile_roles, profile_tasks


### PR DESCRIPTION
It brings little to the table and is making the output quite confusing
for users. It's also not really too relevant with our fairly short-lived
tasks.
