### PR TITLE
Allow picking a custom values-secret.yaml file via the VALUES_SECRET env var

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -35,12 +35,30 @@
   delay: 45
   changed_when: false
 
+# Once V1 support is dropped we can remove the whole secret_template support
 - name: Set secret_template fact
+  no_log: true
   ansible.builtin.set_fact:
     secret_template: "{{ pattern_dir }}/values-secret.yaml.template"
 
+- name: Is a VALUES_SECRET env variable set?
+  ansible.builtin.set_fact:
+    custom_env_values_secret: "{{ lookup('ansible.builtin.env', 'VALUES_SECRET') }}"
+
+- name: Check if VALUES_SECRET file exists
+  ansible.builtin.stat:
+    path: "{{ custom_env_values_secret }}"
+  register: custom_file_values_secret
+  when: custom_env_values_secret | default('') | length > 0
+
+- name: Set values-secret yaml file to {{ custom_file_values_secret.stat.path }}
+  ansible.builtin.set_fact:
+    found_file: "{{ custom_file_values_secret.stat.path }}"
+  when:
+    - custom_env_values_secret | default('') | length > 0
+    - custom_file_values_secret.stat.exists
+
 - name: Find first existing values-secret yaml file
-  no_log: true
   ansible.builtin.set_fact:
     found_file: "{{ lookup('ansible.builtin.first_found', findme) }}"
   vars:
@@ -48,6 +66,7 @@
       - "~/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret.yaml"
       - "{{ pattern_dir }}/values-secret.yaml.template"
+  when: custom_env_values_secret | default('') | length == 0
 
 - name: Is found values secret file encrypted
   no_log: true
@@ -59,6 +78,7 @@
   failed_when: (encrypted.rc not in [0, 1])
 
 - name: Set encryption bool fact
+  no_log: true
   ansible.builtin.set_fact:
     is_encrypted: "{{ encrypted.rc == 0 | bool }}"
 


### PR DESCRIPTION
Tested with:
1. VALUES_SECRET=~/values-secret.yaml.v2 make load-secrets

    TASK [vault_utils : Set values-secret yaml file to /home/michele/values-secret.yaml.v2] ***

2. make load-secrets

    TASK [vault_utils : Find first existing values-secret yaml file] **

Both worked correctly
