### PR TITLE
Add filter_plugins path in common

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -4,3 +4,4 @@ localhost_warning=False
 library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 module_utils=~/.ansible/plugins/module_utils:./plugins/module_utils:/usr/share/ansible/plugins/module_utils
+filter_plugins=~/.ansible/plugins/filter:./plugins/filter:/usr/share/ansible/plugins/filter


### PR DESCRIPTION
While it is not needed just yet, we are likely to need a filter plugin
sooner rather than later, so best if we just prepare the path for it in
common.
