### PR TITLE
Move to draft-07 of the json schema for V2

### DIFF
--- a/ansible/roles/vault_utils/values-secrets.v2.schema.json
+++ b/ansible/roles/vault_utils/values-secrets.v2.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/valuesSecretsV2",
   "meta:license": [
     "Copyright 2022 Red Hat, Inc. All rights reserved.",
@@ -230,7 +230,32 @@
            "description": "When onMissingValue is set to 'generate' and the secret already exists in the vault update it",
            "default": "false"
          }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "onMissingValue": { "const": "prompt" } }
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": ["path"]
+              },
+              {
+                "required": [ "value" ]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": { "onMissingValue": { "const": "generate" } }
+          },
+          "then": {
+            "required": [ "vaultPolicy" ]
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This allows us to use if..then..else statements:
https://json-schema.org/understanding-json-schema/reference/conditionals.html

Now we can require one of 'path' or 'value' attributes whenever
'onMissingValue' is set to 'prompt'.

Also when 'onMissingValue is 'generate' we can require 'vaultPolicy'

Note that the ifs need to be wrapped inside an allOf in order to not
be ignored by the JSON parser (due to multiple keys being the same:
'if', 'then')
