### PR TITLE
Do not raise exception if secret's existence check fails

### DIFF
--- a/ansible/plugins/module_utils/load_secrets_v2.py
+++ b/ansible/plugins/module_utils/load_secrets_v2.py
@@ -42,7 +42,7 @@ class LoadSecretsV2:
         self.pod = pod
         self.syaml = syaml
 
-    def _run_command(self, command, attempts=1, sleep=3):
+    def _run_command(self, command, attempts=1, sleep=3, checkrc=True):
         """
         Runs a command on the host ansible is running on. A failing command
         will raise an exception in this function directly (due to check=True)
@@ -58,7 +58,7 @@ class LoadSecretsV2:
         for attempt in range(attempts):
             ret = self.module.run_command(
                 command,
-                check_rc=True,
+                check_rc=checkrc,
                 use_unsafe_shell=True,
                 environ_update=os.environ.copy(),
             )
@@ -321,7 +321,7 @@ class LoadSecretsV2:
             f'"vault kv get -mount={mount} -field={attribute} {prefix}/{secret_name}"'
         )
         # we ignore stdout and stderr
-        (ret, _, _) = self._run_command(cmd, attempts=1)
+        (ret, _, _) = self._run_command(cmd, attempts=1, checkrc=False)
         if ret == 0:
             return True
 

--- a/ansible/tests/unit/test_vault_load_secrets_v2.py
+++ b/ansible/tests/unit/test_vault_load_secrets_v2.py
@@ -632,10 +632,12 @@ class TestMyModule(unittest.TestCase):
             call(
                 'oc exec -n vault vault-0 -i -- sh -c "vault kv get -mount=secret -field=secret region-one/config-demo"',  # noqa: E501
                 attempts=1,
+                checkrc=False,
             ),
             call(
                 'oc exec -n vault vault-0 -i -- sh -c "vault kv get -mount=secret -field=secret snowflake.blueprints.rhecoeng.com/config-demo"',  # noqa: E501
                 attempts=1,
+                checkrc=False,
             ),
         ]
         mock_run_command.assert_has_calls(calls)


### PR DESCRIPTION
By default _run_command uses check_rc=True. In the secret existence
case, we need to set it to False in order to not raise an exception
when the secret is missing.

Otherwise we'll get the following error:

    TASK [vault_utils : Loads secrets file into the vault of a cluster]
    fatal: [localhost]: FAILED! => {"changed": false, "cmd": "oc exec -n
    vault vault-0 -i -- sh -c 'vault kv get -mount=secret -field=secret
    hub/config-demo'", "msg": "No value found at
    secret/data/hub/config-demo\ncommand terminated with exit code 2", "rc":
    2, "stderr": "No value found at secret/data/hub/config-demo\ncommand
    terminated with exit cod e 2\n", "stderr_lines": ["No value found at
    secret/data/hub/config-demo", "command terminated with exit code 2"],
    "stdout": "", "stdout_lines": []}
