### PR TITLE
Remove stable default from channels

### DIFF
--- a/clustergroup/templates/core/subscriptions.yaml
+++ b/clustergroup/templates/core/subscriptions.yaml
@@ -15,7 +15,9 @@ spec:
   name: {{ $subs.name }}
   source: {{ default "redhat-operators" $subs.source }}
   sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
-  channel: {{ default "stable" $subs.channel }}
+  {{- if $subs.channel }}
+  channel: {{ $subs.channel }}
+  {{- end }}
   installPlanApproval: {{ coalesce $installPlanValue $.Values.global.options.installPlanApproval }}
   {{- if $subs.config }}
   {{- if $subs.config.env }}
@@ -45,7 +47,9 @@ spec:
   name: {{ $subs.name }}
   source: {{ default "redhat-operators" $subs.source }}
   sourceNamespace: {{ default "openshift-marketplace" $subs.sourceNamespace }}
-  channel: {{ default "stable" $subs.channel }}
+  {{- if $subs.channel }}
+  channel: {{ $subs.channel }}
+  {{- end }}
   installPlanApproval: {{ coalesce  $installPlanValue $.Values.global.options.installPlanApproval }}
   {{- if $subs.config }}
   {{- if $subs.config.env }}

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -1513,7 +1513,6 @@ spec:
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  channel: stable
   installPlanApproval: Automatic
   startingCSV:
 ---

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -1012,6 +1012,5 @@ spec:
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  channel: stable
   installPlanApproval: Automatic
   startingCSV: redhat-openshift-pipelines.v1.5.2


### PR DESCRIPTION
Each subscription seems to have a default version, so inserting our own default could get in the way of that. This PR only sets a channel if user requests one.