### PR TITLE
Split secret counter in two variables

### DIFF
--- a/ansible/plugins/module_utils/load_secrets_v2.py
+++ b/ansible/plugins/module_utils/load_secrets_v2.py
@@ -396,8 +396,9 @@ class LoadSecretsV2:
         self.inject_vault_policies()
         secrets = self._get_secrets()
 
-        counter = 0
+        total_secrets = 0  # Counter for all the secrets uploaded
         for s in secrets:
+            counter = 0  # This counter is to use kv put on first secret and kv patch on latter
             sname = s.get("name")
             fields = s.get("fields", [])
             mount = s.get("vaultMount", "secret")
@@ -405,5 +406,6 @@ class LoadSecretsV2:
             for i in fields:
                 self._inject_field(sname, i, mount, vault_prefixes, counter == 0)
                 counter += 1
+                total_secrets += 1
 
-        return counter
+        return total_secrets

--- a/ansible/tests/unit/test_vault_load_secrets_v2.py
+++ b/ansible/tests/unit/test_vault_load_secrets_v2.py
@@ -151,11 +151,11 @@ class TestMyModule(unittest.TestCase):
                 attempts=3,
             ),
             call(
-                "cat '/tmp/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv patch -mount=secret secret/region-two/config-demo-file ca_crt=/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
+                "cat '/tmp/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put -mount=secret secret/region-two/config-demo-file ca_crt=/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
                 attempts=3,
             ),
             call(
-                "cat '/tmp/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv patch -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo-file ca_crt=/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
+                "cat '/tmp/ca.crt' | oc exec -n vault vault-0 -i -- sh -c 'cat - > /tmp/vcontent'; oc exec -n vault vault-0 -i -- sh -c 'base64 --wrap=0 /tmp/vcontent | vault kv put -mount=secret secret/snowflake.blueprints.rhecoeng.com/config-demo-file ca_crt=/tmp/vcontent; rm /tmp/vcontent'",  # noqa: E501
                 attempts=3,
             ),
         ]


### PR DESCRIPTION
The 'counter' variable is used to detect if it is the first vault kv
command to be run (i.e. vault kv put as opposed to vault kv patch for
subsequent runs), so we need to reset it for every top-level secret.
We introduce an additional variable to count every secret entry
uploaded.
