### PR TITLE
Drop any remains of output_file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ uninstall: ## runs helm uninstall
 
 .PHONY: load-secrets
 load-secrets: ## loads the secrets into the vault
-	common/scripts/vault-utils.sh push_secrets common/pattern-vault.init $(NAME)
+	common/scripts/vault-utils.sh push_secrets $(NAME)
 
 CHARTS=$(shell find . -type f -iname 'Chart.yaml' -exec dirname "{}"  \; | grep -v examples | sed -e 's/.\///')
 # Section related to tests and linting

--- a/ansible/roles/vault_utils/README.md
+++ b/ansible/roles/vault_utils/README.md
@@ -32,16 +32,6 @@ vault_hub_ttl: "15m"
 vault_pki_max_lease_ttl: "8760h"
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
-```
-
-Use the local file system (output_file variable) to store the vault's unseal keys.
-If set to false they will be stored inside a secret defined by `unseal_secret`
-in the `imperative` namespace:
-
-```yaml
-# token inside a secret in the cluster.
-# *Note* that this is fundamentally unsafe
-output_file: "common/pattern-vault.init"
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
 ```

--- a/ansible/roles/vault_utils/defaults/main.yml
+++ b/ansible/roles/vault_utils/defaults/main.yml
@@ -14,7 +14,6 @@ vault_base_path: "secret"
 vault_path: "{{ vault_base_path }}/{{ vault_hub }}"
 vault_hub_ttl: "15m"
 vault_pki_max_lease_ttl: "8760h"
-output_file: "common/pattern-vault.init"
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
 external_secrets_secret: golang-external-secrets

--- a/scripts/vault-utils.sh
+++ b/scripts/vault-utils.sh
@@ -21,12 +21,11 @@ if [ $# -lt 1 ]; then
 fi
 
 TASK="${1}"
-OUTFILE=${2:-"$COMMONPATH"/pattern-vault.init}
-PATTERN_NAME=${3:-$(basename "`pwd`")}
+PATTERN_NAME=${2:-$(basename "`pwd`")}
 
 if [ -z ${TASK} ]; then
 	echo "Task is unset"
 	exit 1
 fi
 
-ansible-playbook -t "${TASK}" -e pattern_name="${PATTERN_NAME}" -e pattern_dir="${PATTERNPATH}" -e output_file="${OUTFILE}" "${PLAYBOOKPATH}/vault/vault.yaml"
+ansible-playbook -t "${TASK}" -e pattern_name="${PATTERN_NAME}" -e pattern_dir="${PATTERNPATH}" "${PLAYBOOKPATH}/vault/vault.yaml"


### PR DESCRIPTION
This was only used when we had support for storing the unseal keys in
files. Since we dropped this support we can remove any traces of that.
