### PR TITLE
validation updates

### DIFF
--- a/.github/workflows/ansible-unittest.yml
+++ b/.github/workflows/ansible-unittest.yml
@@ -20,7 +20,7 @@ jobs:
     name: Ansible unit tests
     strategy:
       matrix:
-        python-version: [3.9.15]
+        python-version: [3.11.1]
     # Set the agent to run on
     runs-on: ubuntu-latest
 

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -160,6 +160,10 @@
           "type": "string",
           "description": "The account for the Git provider. Accounts allow you to organize and control access to that code. There are three types of accounts on GitHub.  Personal accounts Organization accounts Enterprise accounts e.g. hybrid-cloud-patterns or claudiol"
         },
+        "username": {
+          "type": "string",
+          "description": "The username for the Git provider."
+        },
         "email": {
           "type": "string",
           "description": "The contact email for the Git account. e.g. account@gmail.com"


### PR DESCRIPTION
- Added callbacks to ansible.cfg
- Updated ansible.cfg with non-deprecated feature.
- Upgrade ESO to 0.6.1
- Make sure we can parse FQDNs after a secrets tag in values-secrets.yaml
- Reorganize tests in preparation for a V2 secrets format
- Add ansible unittest
- Use proper 3.9 version that exists in ubuntu
- Install pytest via pip
- Add ansible in the pip modules
- Add support for creating temporary files and referncing them in tests
- Revert to a simpler way to test file upload
- Add tearDown() in unit tests
- Add ansible/tests/unit/v1/values-secret-good.yaml
- Fix super linter warnings
- Add support for /values-<platform>-<clustergroup>.yaml
- Fix gitleaks file after last unit test change
- Allow multiple test inputs
- Initial v2 plumbing
- Add module_utils path for shared common code
- Move v1 secret functions in module_utils
- Split out common function in separate file
- Move the secret format implementation in classes
- A bunch of cleanups of unit-testing. Still not fully passing
- Have super-linter pass
- Fix patching the right function
- Start unit testing V2 as well
- Add version check in v1 implementation
- Force get_version() to return a string for the time being
- Pass proper parameters to V2 class
- Initial start of vault policies implementation
- More validation and more V2 testing
- Make sure we check if the vaultPolicy exists
- Make error message clearer
- Add a lot more tests and start implementing the files: section
- Fix black errors
- Cleanups and also call check_missing_secrets only on v1.0
- Fix black errors
- Add a test to cover for empty vaultPrefixes
- Add support and tests for the password generation via policy
- Actually use the proper oc exec call to generate secrets
- Implement file uploading as base64 attribute as well
- Move more logic into _get_file_path
- Large rewrite to unify fields and files and add initial base64 support and tests
- Add base64 support for secrets as well and fix up tests
- POC mostly working at this point
- For the time being always stay on getpass.getpass() for input
- Remove unused modules
- Add checks for duplicate secret names and field names
- Switch to using AnsibleModule.run_command
- Make the secret prompting a little prettier
- Implement looking for ~/values-secret-<patternname>.yaml first
- Test base64 secret
- Silence yaml indentation linting errors and more
- Added values-secret examples
- Drop callbacks_enabled
- Add another relevant change in Changes.md
- Error out nicely if yaml.safe_load() cannot parse the file
- Add support for ansible-vault
- Clean up comments in test-cases files and implement backingStore
- Use sensible prompt strings
- Be clearer in the text about ansible-vault
- Move checks that are specific to the version inside classes
- Add a test for erroring out when values_secret_template is not defined and check_missing_secrets is set to true
- Add a default validatedPatternDefaultPolicy password policy
- Forgot to add new test for default vp-policy
- Make sure we re-attempt all vault commands in case of failure
- Add some more documentation
- Add initial v2 schema json file
- Rename the description field to prompt as that is what it is really used for
- value and path can be 'null' when onMissingValue is set to 'prompt'
- Make version a string all the time
- Require some more fields
- Add some more examples to the schema file
- Test json schema CI job
- Fix small ansible lint warning
- Also try {{ pattern_dir }}/values-secret.yaml.template if all others failed
- Fix Changes.md with a small nit
- Prompt ansible-vault password via ansible.builtin.pause
- Make the tasks text less intimidating
- Add json schema for the v1 secret format
- Allow picking a custom values-secret.yaml file via the VALUES_SECRET env var
- Add filter_plugins path in common
- Add override attribute support
- Move to draft-07 of the json schema for V2
- Do not raise exception if secret's existence check fails
- Upgrade vault-helm to v0.23.0
- Filter out patches to test/
- Add patch to be able to use vault-ssl as a default
- Switch to vault-ssl as a default
- Remove stable default from channels
- Split secret counter in two variables
- Validation Schema for common/clustergroup
- - Fixed issues with schema validation in values.schema.json - Modified clustergroup/values.yaml and examples/values-example.yaml to have same sections and values. - Updated tests for  tests/clustergroup-naked.expected.yaml and tests/clustergroup-normal.expected.yaml
- Fixed issues with kubeconform in clustergroup/values.yaml.  Reran make test to generate proper files
- - Updated schema to include all elements in subscriptions - Updated tests associated with clustergroup - Updated values-example.yaml
- applications and subscriptions can be obj and array
- restore values.yaml file to a saner commented default
- Ran values.schema.json through jq to fix indentation issues
- Fix up tests
- Move to draft 0.7 of the schema spec
- Add operatorgroupExcludes which is in examples/industrial-edge-factory.yaml
- namespace is not mandatory in an application
- Fix up some more tests
- add clusterSelector in managedClusterGroups
- Allow clusterRoleYaml to be an array and timeout to be a string
- Add image, tags, extravars to imperative job object
- Add descriptions for SecretStore properties
- move GlobalGit and GitSecret after Main
- Forgot ,
- Move testing targets after the installation ones
- Move some of the oc calls into the legacy target
- Simplify getting the remote git URL associated to the target origin
- Drop legacy-install from common
- Move comments in the right place
- Clean up PHONY targets in Makefile
- Move all testing-related variables closer to the tests target
- Make sure we error out after the legacy removal
- Fix up the main section a bit
- Make subscriptions not mandatory
- Add description to main.git fields
- Drop useCSV from global
- Add description for main.gitops.channel
- Add some descriptions
- Mark useCSV as deprecated
- - Added descriptions for namespaces, subscriptions, managedClusterGroup, applications, and projects
- - Fixed issue with description definition
- drop insecureUnsealVaultInsideCluster entirely
- - Removed insecure boolean from schema file and from values-example.yaml
- Re-ran make tests
- Drop any remains of output_file
- - Added username to the GlobalGit schema definition.
