### PR TITLE
Only set vaultkeys fact when the vault is sealed

### DIFF
--- a/ansible/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_unseal.yaml
@@ -17,12 +17,12 @@
     name: "{{ unseal_secret }}"
     api_version: v1
   register: vault_init_data
-  when:
-    - vault_sealed
+  when: vault_sealed
 
 - name: Does the vaultkeys secret exist?
   ansible.builtin.set_fact:
     vaultkeys_exists: "{{ vault_init_data.resources | length > 0 }}"
+  when: vault_sealed
 
 - name: Vaultkeys does not exist and the vault is sealed, so exit
   ansible.builtin.meta: end_play


### PR DESCRIPTION
All other tasks are run only when the vault is sealed, so no point in
skipping this one
