### PR TITLE
Add SkipDryRunOnMissingResource=true on ClusterPools, ClusterClaims and ManagedClusterSets

### DIFF
--- a/acm/templates/provision/clusterpool.yaml
+++ b/acm/templates/provision/clusterpool.yaml
@@ -6,6 +6,7 @@ kind: ManagedClusterSet
 metadata:
   annotations:
     cluster.open-cluster-management.io/submariner-broker-ns: {{ .name }}-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: {{ .name }}
 spec:
   clusterSelector:
@@ -33,6 +34,7 @@ metadata:
   name: "{{ $poolName }}"
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     cloud: {{ $cloud }}
     region: '{{ $region }}'
@@ -66,6 +68,7 @@ metadata:
   name: '{{ . }}-{{ $group.name }}'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
     clusterClaimName: {{ . }}-{{ $group.name }}

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -26,6 +26,7 @@ metadata:
   name: 'one-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
     clusterClaimName: one-acm-provision-edge
@@ -40,6 +41,7 @@ metadata:
   name: 'two-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
     clusterClaimName: two-acm-provision-edge
@@ -54,6 +56,7 @@ metadata:
   name: 'three-acm-provision-edge'
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     cluster.open-cluster-management.io/createmanagedcluster: "true"
   labels:
     clusterClaimName: three-acm-provision-edge
@@ -68,6 +71,7 @@ metadata:
   name: "aws-ap-acm-provision-edge"
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     cloud: aws
     region: 'ap-southeast-2'
@@ -97,6 +101,7 @@ metadata:
   name: "azure-us-acm-provision-edge"
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     cloud: azure
     region: 'eastus'
@@ -377,6 +382,7 @@ kind: ManagedClusterSet
 metadata:
   annotations:
     cluster.open-cluster-management.io/submariner-broker-ns: acm-provision-edge-broker
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: acm-provision-edge
 spec:
   clusterSelector:


### PR DESCRIPTION
On a deploy using clusterPools the acm app will stay in error forever.
The reason for this is that the CRDs for the above objects won't exist
until the MultiClusterHub is installed. So Argo CD won't find the CRD
in the sync and will fail with the error the server could not find the
requested resource.

Add the "argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true" on those resources, just like we do for Policies.

Co-Authored-By: Lester Claudio <claudiol@redhat.com>
