### PR TITLE
Fix schema json when using HostedArgo

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -231,6 +231,12 @@
             "type": "string"
           }
         },
+        "hostedSite": {
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/HostedSite"
+          }
+        },
         "subscriptions": {
           "anyOf": [
             {
@@ -388,6 +394,23 @@
         "project"
       ],
       "title": "Applications"
+    },
+    "HostedSite": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bearerKeyPath": {
+          "type": "string"
+        },
+        "caKeyPath": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bearerKeyPath",
+        "caKeyPath"
+      ],
+      "title": "HostedSite"
     },
     "Imperative": {
       "type": "object",


### PR DESCRIPTION
When using HostedArgo there is one App for each remote cluster managed
by argo.
Each of these apps gets two helm key/values passed down containing the
bearer token and the remote CA:
clusterGroup.hostedSite.bearerKeyPath
clusterGroup.hostedSite.caKeyPath

Add the object representing the above in the values.schema.json
