### PR TITLE
Set additionalProperties to true for top-level objects

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "ValidatedPatterns": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "enabled": {
           "type": "string",


### PR DESCRIPTION
We're only in charge of global, main, secretstore and clustergroup.
What happens in the other parts othe values file is not our job to
validate.
