### PR TITLE
Extend framework to allow for ESO on ACM-imported clusters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## January 23, 2023
+
+* Add initial support for running ESO on ACM-imported clusters
+
 ## January 18, 2023
 
 * Add validate-schema target

--- a/ansible/playbooks/acm/acmhub-get-ca.yaml
+++ b/ansible/playbooks/acm/acmhub-get-ca.yaml
@@ -1,0 +1,52 @@
+# This playbook fetches the hub cluster's CAbundle from ACM's objects
+# and puts it in a secret inside the imperative namespace
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    ns: imperative
+  tasks:
+    - name: Find hub cluster
+      kubernetes.core.k8s_info:
+        kind: Secret
+        name: hub-kubeconfig-secret
+        namespace: open-cluster-management-agent
+      register: hub_cluster
+
+    - name: Do nothing when no managed clusters are found
+      ansible.builtin.meta: end_play
+      when: hub_cluster['resources'][0]['data']['kubeconfig'] is not defined
+
+    # FIXME(bandini) The assumption here is that there is a single hub cluster for each managed cluster
+    #
+    # oc extract secret/hub-kubeconfig-secret --keys=kubeconfig --to=- -n open-cluster-management-agent
+    # apiVersion: v1
+    # clusters:
+    # - cluster:
+    #     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNakNDQWhxZ0F3SU...
+    #     server: https://api.bandini-dc.blueprints.rhecoeng.com:6443
+    #   name: default-cluster
+    - name: Get hub cluster facts
+      ansible.builtin.set_fact:
+        # kubeconfig is just a b64-econded yaml
+        hub_cluster_kubeconfig: "{{ hub_cluster['resources'][0]['data']['kubeconfig'] | b64decode | from_yaml }}"
+
+    - name: Set CA fact
+      ansible.builtin.set_fact:
+        # The .get() call is needed because the key has dashes in it
+        hub_cluster_ca: "{{ hub_cluster_kubeconfig.clusters[0].cluster.get('certificate-authority-data') }}"
+
+    - name: Create secret with managed cluster's CA
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: Secret
+          apiVersion: v1
+          metadata:
+            name: "hub"
+            namespace: "{{ ns }}"
+          data:
+            caBundle: "{{ hub_cluster_ca }}"
+          type: Opaque

--- a/ansible/roles/vault_utils/tasks/main.yml
+++ b/ansible/roles/vault_utils/tasks/main.yml
@@ -11,6 +11,10 @@
   ansible.builtin.import_tasks: vault_secrets_init.yaml
   tags: vault_secrets_init
 
+- name: Vault spoke backend init
+  ansible.builtin.import_tasks: vault_spokes_init.yaml
+  tags: vault_spokes_init
+
 - name: Load secrets
   ansible.builtin.import_tasks: push_secrets.yaml
   tags: push_secrets

--- a/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -1,0 +1,184 @@
+---
+- name: Vault pre checks
+  ansible.builtin.include_tasks: pre_check.yaml
+
+- name: Find managed clusters
+  kubernetes.core.k8s_info:
+    kind: ManagedCluster
+    api_version: "cluster.open-cluster-management.io/v1"
+  register: managed_clusters
+
+- name: Set resource fact
+  ansible.builtin.set_fact:
+    resources: "{{ managed_clusters['resources'] }}"
+
+- name: Do nothing when no managed clusters are found
+  ansible.builtin.meta: end_play
+  when: resources | length == 0 or managed_clusters.failed or not managed_clusters.api_found
+
+- name: Loop over returned ACM managedclusters
+  ansible.builtin.set_fact:
+    clusters: "{{ clusters|default({}) | combine( { item.metadata.name: { 'caBundle': item.spec.managedClusterClientConfigs[0].caBundle | b64decode } } ) }}"
+  loop: "{{ resources }}"
+  when: item.spec.managedClusterClientConfigs[0].caBundle is defined
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Extract ClusterGroup
+  ansible.builtin.set_fact:
+    clusters: "{{ clusters|default({}) | combine( { item.metadata.name: { 'clusterGroup': item.metadata.labels.clusterGroup } }, recursive=True ) }}"
+  when: "'clusterGroup' in item.metadata.labels"
+  loop: "{{ resources }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Fetch all ACM secrets
+  kubernetes.core.k8s_info:
+    kind: Secret
+    label_selectors:
+    - "apps.open-cluster-management.io/secret-type=acm-cluster"
+  register: acm_secrets
+
+- name: Set cleaned_acm_secrets fect
+  ansible.builtin.set_fact:
+    cleaned_acm_secrets: "{{ acm_secrets.resources | parse_acm_secrets }}"
+
+- name: Merge the two dicts together
+  ansible.builtin.set_fact:
+    clusters_info: "{{ clusters | combine(cleaned_acm_secrets, recursive=True) }}"
+
+- name: write out CAs
+  ansible.builtin.copy:
+    content: "{{ item.value['caBundle'] }}"
+    dest: "/tmp/{{ item.key }}.ca"
+  loop: "{{ clusters_info | dict2items }}"
+  when: item.value['caBundle'] is defined
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Fetch remote ansible to remote cluster
+  kubernetes.core.k8s_info:
+    api_key: "{{ item.value['bearerToken'] }}"
+    ca_cert: /tmp/{{ item.key}}.ca
+    host: "{{ item.value['server_api'] }}"
+    kind: Secret
+    namespace: "{{ external_secrets_ns }}"
+    name: "{{ external_secrets_secret }}"
+    api_version: v1
+  register: remote_external_secrets_sa
+  when:
+    - clusters_info[item.key]['bearerToken'] is defined
+    - clusters_info[item.key]['server_api'] is defined
+    - clusters_info[item.key]['caBundle'] is defined
+  loop: "{{ clusters_info | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+# 'token' will be empty if the remote cluster has no golang-external-secret
+# app configured and running
+- name: Loop over returned ESO tokens
+  ansible.builtin.set_fact:
+    clusters_info: "{{ clusters_info | default({}) | combine({ item['item']['key']: { 'esoToken': item['resources'][0]['data']['token'] | b64decode}}, recursive=True) }}"
+  loop: "{{ remote_external_secrets_sa.results }}"
+  when: item['resources'][0]['data']['token'] is defined
+  loop_control:
+    label: "{{ item['item']['key'] }}"
+
+# At this point clusters_info contains a per cluster hash table with *all* the right attributes. For example:
+# "mcg-one": {
+#   "bearerToken": "ey...",
+#   "caBundle": "-----BEGIN CERTIFICATE-----\nMIIDMjCCA",
+#   "clusterGroup": "group-one",
+#   "cluster_fqdn": "mcg-one.blueprints.rhecoeng.com",
+#   "vault_path": "hub" (when the hub) and the cluster_fqdn when not hub,
+#   "esoToken": (optional) only if there was an external golang-external-secrets namespace+service account
+#   "name": "mcg-one",
+#   "server_api": "https://api.mcg-one.blueprints.rhecoeng.com:6443",
+#   "tlsClientConfig": {
+#     "insecure": true
+#   }
+# }
+- name: Dump CABundles into the vault
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: bash -e -c "echo '{{ item.value['caBundle'] }}' > /tmp/{{ item.value['vault_path'] }}.ca"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Is kubernetes backend already enabled
+  no_log: true
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: bash -e -c "if vault auth list | grep -e ^'{{ item.value['vault_path'] }}'; then
+        echo done; else
+        vault auth enable -path='{{ item.value['vault_path'] }}' kubernetes; fi"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure kubernetes backend
+  no_log: true
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: bash -e -c "vault write auth/{{ item.value['vault_path'] }}/config
+        token_reviewer_jwt=\"{{ item.value['esoToken'] }}\"
+        kubernetes_host=\"{{ item.value['server_api'] }}\"
+        kubernetes_ca_cert=@/tmp/{{ item.value['vault_path'] }}.ca"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure policy template
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      bash -e -c "echo \"path \\\"secret/data/{{ item.value['vault_path'] }}/*\\\" {
+        capabilities = {{ vault_hub_capabilities }} }\" > /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure policy for spokes
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: "vault policy write {{ item.value['vault_path'] }}-secret /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Configure kubernetes role for spokes
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      vault write auth/"{{ item.value['vault_path'] }}"/role/"{{ item.value['vault_path'] }}"-role
+        bound_service_account_names="{{ external_secrets_ns }}"
+        bound_service_account_namespaces="{{ external_secrets_sa }}"
+        policies="default,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_hub_ttl }}"
+  loop: "{{ clusters_info | dict2items }}"
+  when:
+    - item.value['esoToken'] is defined
+    - item.key != "local-cluster"
+  loop_control:
+    label: "{{ item.key }}"

--- a/clustergroup/templates/imperative/unsealjob.yaml
+++ b/clustergroup/templates/imperative/unsealjob.yaml
@@ -41,8 +41,61 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
+              volumeMounts:
+                {{- include "imperative.volumemounts" . | indent 16 }}
+          containers:
+          {{- include "imperative.containers.done" . | indent 12 }}
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: {{ $.Values.clusterGroup.imperative.valuesConfigMap }}-{{ $.Values.clusterGroup.name }}
+          restartPolicy: Never
+{{- else }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: acmhub-ca-cronjob
+  namespace: {{ $.Values.clusterGroup.imperative.namespace}}
+spec:
+  schedule: {{ $.Values.clusterGroup.imperative.insecureUnsealVaultInsideClusterSchedule | quote }}
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ $.Values.clusterGroup.imperative.activeDeadlineSeconds }}
+      template:
+        metadata:
+          name: acmhub-ca-job
+        spec:
+          serviceAccountName: {{ $.Values.clusterGroup.imperative.serviceAccountName }}
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there
+            {{- include  "imperative.initcontainers.gitinit" . | indent 12 }}
+            - name: acmhub-ca-playbook
+              image: {{ $.Values.clusterGroup.imperative.image }}
+              imagePullPolicy: {{ $.Values.clusterGroup.imperative.imagePullPolicy }}
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - {{ .timeout | default "600" | quote }}
+                - ansible-playbook
+                {{- if $.Values.clusterGroup.imperative.verbosity }}
+                - {{ $.Values.clusterGroup.imperative.verbosity }}
+                {{- end }}
+                - -e
+                - "@/values/values.yaml"
+                - "common/ansible/playbooks/acm/acmhub-get-ca.yaml"
               volumeMounts:
                 {{- include "imperative.volumemounts" . | indent 16 }}
           containers:

--- a/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -10,15 +10,28 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+{{ if .Values.clusterGroup.isHubCluster }}
       caProvider:
         type: ConfigMap
         name: kube-root-ca.crt
         key: ca.crt
         namespace: golang-external-secrets
+{{ else }}
+      caProvider:
+        type: Secret
+        name: hub
+        key: caBundle
+        namespace: imperative
+{{ end }}
       auth:
         kubernetes:
+{{ if .Values.clusterGroup.isHubCluster }}
           mountPath: {{ .Values.mountPath }}
           role: {{ .Values.mountRole }}
+{{ else }}
+          mountPath: {{ $.Values.global.clusterDomain }}
+          role: {{ $.Values.global.clusterDomain }}-role
+{{ end }}
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets

--- a/golang-external-secrets/values.yaml
+++ b/golang-external-secrets/values.yaml
@@ -4,6 +4,12 @@ mountRole: "hub-role"
 
 global:
   hubClusterDomain: hub.example.com
+  clusterDomain: foo.example.com
+
+clusterGroup:
+  isHubCluster: true
+
+
 
 external-secrets:
   image:

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -336,6 +336,80 @@ spec:
               name: helm-values-configmap-factory
           restartPolicy: Never
 ---
+# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: acmhub-ca-cronjob
+  namespace: imperative
+spec:
+  schedule: "*/5 * * * *"
+  # if previous Job is still running, skip execution of a new Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          name: acmhub-ca-job
+        spec:
+          serviceAccountName: imperative-sa
+          initContainers:
+            # git init happens in /git/repo so that we can set the folder to 0770 permissions
+            # reason for that is ansible refuses to create temporary folders in there            
+            - name: git-init
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              command:
+              - 'sh'
+              - '-c'
+              - "mkdir /git/{repo,home};git clone --single-branch --branch main --depth 1 -- https://github.com/pattern-clone/mypattern /git/repo;chmod 0770 /git/{repo,home}"
+              volumeMounts:
+              - name: git
+                mountPath: "/git"
+            - name: acmhub-ca-playbook
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              env:
+                - name: HOME
+                  value: /git/home
+              workingDir: /git/repo
+              # We have a default timeout of 600s for each playbook. Can be overridden
+              # on a per-job basis
+              command:
+                - timeout
+                - "600"
+                - ansible-playbook
+                - -e
+                - "@/values/values.yaml"
+                - "common/ansible/playbooks/acm/acmhub-get-ca.yaml"
+              volumeMounts:                
+                - name: git
+                  mountPath: "/git"
+                - name: values-volume
+                  mountPath: /values/values.yaml
+                  subPath: values.yaml
+          containers:            
+            - name: "done"
+              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              imagePullPolicy: Always
+              command:
+                - 'sh'
+                - '-c'
+                - 'echo'
+                - 'done'
+                - '\n'
+          volumes:
+          - name: git
+            emptyDir: {}
+          - name: values-volume
+            configMap:
+              name: helm-values-configmap-factory
+          restartPolicy: Never
+---
 # Source: pattern-clustergroup/templates/core/subscriptions.yaml
 ---
 ---

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -547,7 +547,7 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:                
                 - name: git

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -534,7 +534,7 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:                
                 - name: git

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -227,7 +227,7 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:                
                 - name: git

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -416,7 +416,7 @@ spec:
                 - -e
                 - "@/values/values.yaml"
                 - -t
-                - 'vault_init,vault_unseal,vault_secrets_init'
+                - 'vault_init,vault_unseal,vault_secrets_init,vault_spokes_init'
                 - "common/ansible/playbooks/vault/vault.yaml"
               volumeMounts:                
                 - name: git

--- a/tests/golang-external-secrets-industrial-edge-factory.expected.yaml
+++ b/tests/golang-external-secrets-industrial-edge-factory.expected.yaml
@@ -7281,15 +7281,19 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+
       caProvider:
-        type: ConfigMap
-        name: kube-root-ca.crt
-        key: ca.crt
-        namespace: golang-external-secrets
+        type: Secret
+        name: hub
+        key: caBundle
+        namespace: imperative
+
       auth:
         kubernetes:
-          mountPath: hub
-          role: hub-role
+
+          mountPath: region.example.com
+          role: region.example.com-role
+
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets

--- a/tests/golang-external-secrets-industrial-edge-hub.expected.yaml
+++ b/tests/golang-external-secrets-industrial-edge-hub.expected.yaml
@@ -7281,15 +7281,19 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+
       caProvider:
         type: ConfigMap
         name: kube-root-ca.crt
         key: ca.crt
         namespace: golang-external-secrets
+
       auth:
         kubernetes:
+
           mountPath: hub
           role: hub-role
+
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets

--- a/tests/golang-external-secrets-medical-diagnosis-hub.expected.yaml
+++ b/tests/golang-external-secrets-medical-diagnosis-hub.expected.yaml
@@ -7281,15 +7281,19 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+
       caProvider:
         type: ConfigMap
         name: kube-root-ca.crt
         key: ca.crt
         namespace: golang-external-secrets
+
       auth:
         kubernetes:
+
           mountPath: hub
           role: hub-role
+
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets

--- a/tests/golang-external-secrets-naked.expected.yaml
+++ b/tests/golang-external-secrets-naked.expected.yaml
@@ -7281,15 +7281,19 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+
       caProvider:
         type: ConfigMap
         name: kube-root-ca.crt
         key: ca.crt
         namespace: golang-external-secrets
+
       auth:
         kubernetes:
+
           mountPath: hub
           role: hub-role
+
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets

--- a/tests/golang-external-secrets-normal.expected.yaml
+++ b/tests/golang-external-secrets-normal.expected.yaml
@@ -7281,15 +7281,19 @@ spec:
       path: secret
       # Version of KV backend
       version: v2
+
       caProvider:
         type: ConfigMap
         name: kube-root-ca.crt
         key: ca.crt
         namespace: golang-external-secrets
+
       auth:
         kubernetes:
+
           mountPath: hub
           role: hub-role
+
           secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets


### PR DESCRIPTION
This change does three main things:
1. It extends the vault unseal job on the hub with a few tasks that fetch all
   non-hub ACM clusters and for each cluster it connects to the remote
   cluster API endpoint, fetches the golang-external-secret SA token
   and uses it to configure the secret auth/<clusterfqdn>/config
   kubernetes vault backend. If no clusters exist, the additional tasks
   do nothing. Furhtermore, the tasks are also idempotent.

2. It adds a job called acmhub-ca-cronjob on the non-hub clusters which
   will fetch the ACM hub's CA and put it in a secret called "hub" in
   the imperative namespace. Idempotent and noop when the cluster is not
   part of ACM

3. When the golang-external-secrets chart is included on a spoke
   cluster, it will automatically point to the vault on the hub

With this change a spoke cluster may decide to install the
golang-external-secrets chart on a spoke and avoid pushing secrets
around via ACM. By doing so we allow a developer to decide if ESO on the
spokes is wanted and we also do not break the existing way of doing
things.

Tested with https://github.com/mbaldessari/multicloud-gitops/commit/4d90c85149fe0a957f6a69666472a51a9bb37c6b
and was able to get MCG working on HUB and spoke with two different
secrets.
