### PR TITLE
Fix some validation schema warnings

### DIFF
--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -41,7 +41,7 @@ clusterGroup:
     clusterRoleYaml: ""
     roleName: imperative-role
     roleYaml: ""
-  managedClusterGroups: []
+  managedClusterGroups: {}
   namespaces: []
 #  - name: factory
 #    # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git
@@ -60,7 +60,7 @@ clusterGroup:
 #
 #  - open-cluster-management
 #
-  subscriptions: []
+  subscriptions: {}
 #  - name: advanced-cluster-management
 #    namespace: open-cluster-management
 #    source: redhat-operators
@@ -70,7 +70,7 @@ clusterGroup:
   projects: []
 #  - datacenter
 #
-  applications: []
+  applications: {}
 #  - name: acm
 #    namespace: default
 #    project: datacenter

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -104,7 +104,7 @@ data:
         valuesConfigMap: helm-values-configmap
         verbosity: ""
       isHubCluster: false
-      managedClusterGroups: []
+      managedClusterGroups: {}
       name: factory
       namespaces:
       - manuela-stormshift-line-dashboard

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -37,7 +37,7 @@ metadata:
 data:
   values.yaml: |
     clusterGroup:
-      applications: []
+      applications: {}
       imperative:
         activeDeadlineSeconds: 3600
         clusterRoleName: imperative-cluster-role
@@ -57,11 +57,11 @@ data:
         valuesConfigMap: helm-values-configmap
         verbosity: ""
       isHubCluster: true
-      managedClusterGroups: []
+      managedClusterGroups: {}
       name: example
       namespaces: []
       projects: []
-      subscriptions: []
+      subscriptions: {}
       targetCluster: in-cluster
     enabled: all
     global:


### PR DESCRIPTION
Before this change:

    $ helm template common/clustergroup --name-template multicloud-gitops  -f ~/Engineering/cloud-patterns/multicloud-gitops/values-hub.yaml >/dev/null
    coalesce.go:223: warning: destination for pattern-clustergroup.clusterGroup.managedClusterGroups is a table. Ignoring non-table value ([])
    coalesce.go:223: warning: destination for pattern-clustergroup.clusterGroup.subscriptions is a table. Ignoring non-table value ([])
    coalesce.go:223: warning: destination for pattern-clustergroup.clusterGroup.applications is a table. Ignoring non-table value ([])

After this change:

    $ helm template common/clustergroup --name-template multicloud-gitops  -f ~/Engineering/cloud-patterns/multicloud-gitops/values-hub.yaml >/dev/null
    $
