### PR TITLE
Introduce a validate-schema Makefile target

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## January 18, 2023
+
+* Add validate-schema target to default deploy
+
 ## January 13, 2023
 
 * Simplify the secrets paths when using argo hosted sites

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,15 @@ validate-origin: ## verify the git origin is available
 		echo "Running inside a container: Skipping git ssh checks";\
 	fi
 
+.PHONY: validate-schema
+validate-schema: ## validates values files against schema in common/clustergroup
+	$(eval VAL_PARAMS := $(shell for i in ./values-*.yaml; do echo -n "$${i} "; done))
+	@echo -n "Validating clustergroup schema of: "
+	@set -e; for i in $(VAL_PARAMS); do echo -n " $$i"; helm template common/clustergroup $(HELM_OPTS) -f "$${i}" >/dev/null; done
+	@echo
+
 .PHONY: operator-deploy operator-upgrade
-operator-deploy operator-upgrade: validate-origin ## runs helm install
+operator-deploy operator-upgrade: validate-origin validate-schema ## runs helm install
 	helm upgrade --install $(NAME) common/operator-install/ $(HELM_OPTS)
 
 .PHONY: deploy upgrade legacy-deploy legacy-upgrade


### PR DESCRIPTION
This checks all the values file singularly and together with
./values-global.yaml against common/clustergroup schema.
Working example:

    $ make validate-schema
    make -f common/Makefile validate-schema
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Validating clustergroup schema of:  ./values-global.yaml ./values-group-one.yaml ./values-hub.yaml
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'

With an error in values-global.yaml:

    $ make -f common/Makefile validate-schema
    make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
    Validating clustergroup schema of:  ./values-global.yamlError: values don't meet the specifications of the schema(s) in the following chart(s):
    pattern-clustergroup:
    - global.options.useCSV: Invalid type. Expected: boolean, given: string

make[1]: *** [common/Makefile:42: validate-schema] Error 1
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'
make: *** [Makefile:10: validate-schema] Error 2
