### PR TITLE
helmOverride.value can be both a string and a boolean

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -627,7 +627,14 @@
           "type": "string"
         },
         "value": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
We saw the following error in one of the QE jobs:

    Error: values don't meet the specifications of the schema(s) in the following chart(s):
    pattern-clustergroup:
    - clusterGroup.managedClusterGroups.0.helmOverrides.0.value: Invalid type. Expected: string, given: boolean

It can be that the value associated with helmOverride[x].value is also a
boolean and not only a string, so let's relax this restriction.
