### PR TITLE
Allow subscriptions to be null

### DIFF
--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -239,6 +239,9 @@
         "subscriptions": {
           "anyOf": [
             {
+              "type": "null"
+            },
+            {
               "type": "array"
             },
             {


### PR DESCRIPTION
There are different vlaues files around where subscriptions is defined
but unset (values-group-one.yaml is currently an example).

check-jsonschema will barf on these with:
  $.clusterGroup.subscriptions: None is not of type 'array'

Let's allow them to be defined but set to nothing (aka null)
