### PR TITLE
Switch to quay.io/hybridcloudpatterns/utility-container

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
-	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/hybridcloudpatterns-utility-ee"
+	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
 
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
-# /home/runner is the normal homedir
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials
 # We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
@@ -25,7 +24,6 @@ podman run -it \
 	--security-opt label=disable \
 	${KUBECONF_ENV} \
 	${SSH_SOCK_MOUNTS} \
-	-v ${HOME}:/home/runner \
 	-v ${HOME}:${HOME} \
 	-v ${HOME}:/root \
 	-w $(pwd) \


### PR DESCRIPTION
This container is managed and build via the utility-container repository
in our github organization. Main reason for switching is size (1.1G vs
2.6G) but it also seems a bit simpler to maintain via a single
Containerfile.
