### PR TITLE
Drop SSH_SOCK_MOUNT from pattern-util.sh

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -7,11 +7,6 @@ fi
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials
-# We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
-SSH_SOCK_MOUNTS=""
-if [ -n "$SSH_AUTH_SOCK" ]; then
-	SSH_SOCK_MOUNTS="-v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK} -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK}"
-fi
 
 # We must pass -e KUBECONFIG *only* if it is set, otherwise we end up passing
 # KUBECONFIG="" which then will confuse ansible


### PR DESCRIPTION
As reported by Jonny this might be problematic on some Mac OSX versions.
While the investigation still needs to be done, we can safely drop this
additional mount point because in the 'validate-origin' target we are
currently skipping the 'git ls-remote' call when running inside the
container.

We can reassess this at a later time and debug all these corner case,
but it will only make sense if we run the git ls-remote check in the
container as well.
