### PR TITLE
Bail out on unsupported podman versions

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -4,6 +4,16 @@ if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
 
+UNSUPPORTED_PODMAN_VERSIONS="1.6 1.5"
+for i in ${UNSUPPORTED_PODMAN_VERSIONS}; do
+	# We add a space
+	if podman --version | grep -q -E "\b${i}"; then
+		echo "Unsupported podman version. We recommend >= 4.2.0"
+		podman --version
+		exit 1
+	fi
+done
+
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials


### PR DESCRIPTION
Tested on Fedora and on Mac OSX. We use the grep -E on the '\b' word
boundary to be a bit more resilient in our grep.
