### PR TITLE
Define pre-release catalog sources from the install command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ ifneq ($(origin TARGET_SITE), undefined)
   TARGET_SITE_OPT=--set main.clusterGroupName=$(TARGET_SITE)
 endif
 
+# INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:394248
+INDEX_IMAGES ?= 
+INDEX_OPTIONS=$(shell echo $(INDEX_IMAGES) | tr ',' '\n' | awk -F: 'match($$1,"/"){print "--set main.extraParameters."NR".name=clusterGroup.indexImages."NR".image --set main.extraParameters."NR".value="$$1":"$$2}')
+
 TARGET_ORIGIN ?= origin
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
 # This is because we expect to use tokens for repo authentication as opposed to SSH keys
@@ -11,7 +15,7 @@ TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e '
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT)
+HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(INDEX_OPTIONS)
 
 ##@ Pattern Common Tasks
 

--- a/clustergroup/templates/core/catalog-sources.yaml
+++ b/clustergroup/templates/core/catalog-sources.yaml
@@ -1,13 +1,14 @@
 {{- if not (eq .Values.enabled "plumbing") }}
 {{- range .Values.clusterGroup.indexImages }}
+{{- $name := mustRegexReplaceAll "[^/]*/(.*):.*" .image "${1}" | replace "/" "-" }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: {{ .name }}
+  name: {{ coalesce .name $name }}
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: {{ .image }}:{{ .version }}
+  image: {{ .image }}
 ---
 {{- end -}}
 {{- end -}}

--- a/clustergroup/test.yaml
+++ b/clustergroup/test.yaml
@@ -10,8 +10,7 @@ clusterGroup:
 
   indexImages:
   - name: snr
-    image: quay.io/mshitrit/self-node-remediation-manager-index
-    version: 0.0.104
+    image: quay.io/mshitrit/self-node-remediation-manager-index:0.0.104
 
   subscriptions:
     acm:

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -223,6 +223,13 @@
             "type": "string"
           }
         },
+        "indexImages": {
+          "type": "array",
+          "description": "List of index images for overriding default catalog sources.",
+          "items": {
+            "$ref": "#/definitions/IndexImages"
+          }
+        },
         "operatorgroupExcludes": {
           "type": "array",
           "description": "List of namespaces to exclude the creation of operator groups.",
@@ -395,6 +402,21 @@
         "project"
       ],
       "title": "Applications"
+    },
+    "IndexImages": {
+      "type": "object",
+      "description": "Details for overriding default catalog sources",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name for the custom catalog source."
+        },
+        "image": {
+          "type": "string",
+          "description": "Location of the index image."
+        }
+      }
     },
     "HostedSite": {
       "type": "object",

--- a/clustergroup/values.schema.json
+++ b/clustergroup/values.schema.json
@@ -224,7 +224,14 @@
           }
         },
         "indexImages": {
-          "type": "array",
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ],
           "description": "List of index images for overriding default catalog sources.",
           "items": {
             "$ref": "#/definitions/IndexImages"

--- a/operator-install/templates/pattern.yaml
+++ b/operator-install/templates/pattern.yaml
@@ -10,3 +10,10 @@ spec:
     targetRevision: {{ .Values.main.git.revision }}
   gitOpsSpec:
     operatorChannel: {{ default "stable" .Values.main.gitops.channel }}
+{{- if .Values.main.extraParameters }}
+  extraParameters:
+{{- range .Values.main.extraParameters }}
+  - name: {{ .name }}
+    value: {{ .value }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
QE needs the ability to deploy patterns with a specific set of CatalogSources corresponding to pre-release operator versions.

This PR facilitates that without requiring deployment specific git commits.