### PR TITLE
Add SkipDryRunOnMissingResource=true to all PlacementRules

### DIFF
--- a/acm/templates/policies/acm-hub-ca-policy.yaml
+++ b/acm/templates/policies/acm-hub-ca-policy.yaml
@@ -55,6 +55,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/acm/templates/policies/application-policies.yaml
+++ b/acm/templates/policies/application-policies.yaml
@@ -124,6 +124,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: {{ .name }}-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -64,6 +64,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/acm-industrial-edge-factory.expected.yaml
+++ b/tests/acm-industrial-edge-factory.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -105,6 +109,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: region-one-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -96,6 +100,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -470,6 +470,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -486,6 +488,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -499,6 +503,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-provision-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -512,6 +518,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'


### PR DESCRIPTION
All other objects under common/acm already have this sync-option.

Now the reason this is mandatory is because during sync-wave: -1 we
create the "kind: MultiClusterHub" which actually installs the operator
which creates all the ACM objects we then use (PlacementRules,
PlacementBindings, Policies). Then during the default sync-wave ("0") we
create all other objects.

The most astute reader will wonder why this is needed at all, since on
paper, on wave "-1" MCH gets created/installed and later during wave "0"
all the objects dependent on MCG should be installed. Well, buckle up,
my friend:
Argo will just straight out refuse to proceed syncing any object (MCH
included) unless those objects have the SkipDryRunOnMissingResource=true
annotation set. In this case sync-waves do not matter *at all*.

The logs in the gitops server will be something along these lines:

    time="2023-03-08T11:28:02Z" level=info msg="Adding resource result, status: 'SyncFailed', phase: '', message: 'the server could not find the requested resource'" application=acm kind=PlacementRule

What makes this even more "fun" is that this has always worked for us up
until ACM 2.7 when MCH suddenly stopped being installed. Likely it all
has worked by pure accident until now and the new ACM/MCH combo triggers
a slight different ordering which sets us up for the current bag of
fail.

Tested this with both ACM 2.7 and ACM 2.6 and ACM + MCH got installed
correctly.

Closes: MBP-458
