### PR TITLE
Do not quote KUBECONF_ENV

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -25,9 +25,11 @@ if [ -n "$KUBECONFIG" ]; then
 	KUBECONF_ENV="-e KUBECONFIG=${KUBECONFIG}"
 fi
 
+# Do not quote the ${KUBECONF_ENV} below, otherwise we will pass '' to podman
+# which will be confused
 podman run -it \
 	--security-opt label=disable \
-	"${KUBECONF_ENV}" \
+	${KUBECONF_ENV} \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \
 	-v "${HOME}":/root \


### PR DESCRIPTION
It is already quoted above, so there is no need for the additional
quoting which is actually harmful when it is already unset
as we are going to pass down an empty '' to podman which will be
confused.
