### PR TITLE
Add support for ~/.config/hybrid-cloud-patterns folder to store secrets

### DIFF
--- a/ansible/roles/vault_utils/README.md
+++ b/ansible/roles/vault_utils/README.md
@@ -44,8 +44,9 @@ This relies on [kubernetes.core](https://docs.ansible.com/ansible/latest/collect
 
 Currently this role supports two formats: version 1.0 (which is the assumed default when not specified) and version 2.0.
 The latter is more fatureful and supports generating secrets directly into the vault and also prompting the user for a secret.
-By default, the first file that will looked up is `~/values-secret-<patternname>.yaml` and should that not exist it will look
-for `~/values-secret.yaml`. The paths can be overridden by setting the environment variable `VALUES_SECRET` to the path of the
+By default, the first file that will looked up is `~/.config/hybrid-cloud-patterns/values-secret-<patternname>.yaml`, then
+`~/values-secret-<patternname>.yaml` and should that not exist it will look for `~/values-secret.yaml`.
+The paths can be overridden by setting the environment variable `VALUES_SECRET` to the path of the
 secret file.
 
 The values secret yaml files can be encrypted with `ansible-vault`. If the role detects they are encrypted, the password to

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -63,6 +63,7 @@
     found_file: "{{ lookup('ansible.builtin.first_found', findme) }}"
   vars:
     findme:
+      - "~/.config/hybrid-cloud-patterns/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret.yaml"
       - "{{ pattern_dir }}/values-secret.yaml.template"

--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -58,6 +58,8 @@
     - custom_env_values_secret | default('') | length > 0
     - custom_file_values_secret.stat.exists
 
+# FIXME(bandini): Eventually around end of 2023(?) we should drop
+# ~/values-secret-{{ pattern_name }}.yaml and ~/values-secret.yaml
 - name: Find first existing values-secret yaml file
   ansible.builtin.set_fact:
     found_file: "{{ lookup('ansible.builtin.first_found', findme) }}"


### PR DESCRIPTION
One point of feedback received lately, was that having
~/values-secrets*yaml files straight in the ~ folder can clutter the
home folder. Add support for storing them inside the ~/.patterns folder.

Overriding the location completely via VALUES_SECRET is still supported.
