### PR TITLE
Add more logic to `install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,21 @@ help: ## This help message
 show: ## show the starting template without installing it
 	helm template common/operator-install/ --name-template $(NAME) $(HELM_OPTS)
 
+# Only call helm install if the CRD is missing. If it already exists just
+# push the templated files.
+# The reason we have two helm template calls in the else branch is to avoid
+# warnings when the chart gets applied the first time, but the resources were
+# created first via the VP operator's UI
 .PHONY: operator-deploy
 operator-deploy operator-upgrade: validate-prereq validate-origin ## runs helm install
-	@echo "Running helm:"
-	helm upgrade --install $(NAME) common/operator-install/ $(HELM_OPTS)
+	@set -e; if ! oc get crds patterns.gitops.hybrid-cloud-patterns.io >/dev/null 2>&1; then \
+	  echo "Running helm:"; \
+	  helm upgrade --install $(NAME) common/operator-install/ $(HELM_OPTS); \
+	else \
+	  echo "Reapplying helm chart:"; \
+	  helm template --name-template $(NAME) common/operator-install/ $(HELM_OPTS) | oc apply set-last-applied --create-annotation -f-; \
+	  helm template --name-template $(NAME) common/operator-install/ $(HELM_OPTS) | oc apply -f-; \
+	fi
 
 .PHONY: uninstall
 uninstall: ## runs helm uninstall
@@ -130,4 +141,3 @@ ansible-unittest: ## run ansible unit tests
 .PHONY: deploy upgrade legacy-deploy legacy-upgrade
 deploy upgrade legacy-deploy legacy-upgrade:
 	@echo "UNSUPPORTED TARGET: please switch to 'operator-deploy'"; exit 1
-


### PR DESCRIPTION
So this commit aims to tweak the `install` make target so that it can be
invoked whenever we need to tweak things like git branch or git repo via
CLI but the VP pattern has been installed via the OperatorHub.
Currently if you just run `make install` from the repo after the
operator has been installed via the Web UI, there will be an error like:
```
Error: rendered manifests contain a resource that already exists. Unable
to continue with install: Pattern "multicloud-gitops" in namespace
"openshift-operators" exists and cannot be imported into the current
release: invalid ownership metadata; label validation error: missing key
"app.kubernetes.io/managed-by": must be set to "Helm"; annotation
validation error: missing key "meta.helm.sh/release-name": must be set
to "multicloud-gitops"; annotation validation error: missing key
"meta.helm.sh/release-namespace": must be set to "default"
```

The problem is that the pattern object and the patterns operator
subscription are missing some annotations and labels and that confuses
helm install later on as it sees the object it needs to create but craps
itself as it has no knowledge of it.

A few approaches were investigated to solve this:
1. Tweak the operator to add annotations. This, besides being a bit
   fragile and convoluted, is not a viable path, because the operator
   would also have to tweak the subscription that was used to install
   itself, which seems grossly out of bounds.
2. Tweak `make install` to always use `helm template` and pipe it
   through `oc apply`. This quickly would become rather complex and
   fragile because of the way CRDs are managed in helm: we would have to
   first install the CRD, wait for its successful creation and only then
   do another `helm template ... | oc apply -f-`. This quickly becomes
   rather involved and fragile. Also it is really reimplementing all of
   the `helm install` logic.
3. Add a post-renderer script to strip the standard helm annotations
   (https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
   Seemingly helm does not pass those annotations to the post renderer
   but adds them afterwards, because a --post-renderer pointing to a
   script that does `yq e 'del(.metadata.annotations)'` did not work

Given the above limits, I decided to tweak `make install` so that if the
CRD for the pattern is missing, it would just run the usual helm
install. If the CRD is present then either it has been installed via the
operator's UI or via `make install`. Either way, we just just run helm
template and pipe it to oc apply, so that we won't force the helm
standard annotations.

We have two invocations of helm template (one piped to oc apply
set-last-applied) so we avoid the following warning during the first
reapply call:

    Warning: resource patterns/multicloud-gitops is missing the
    kubectl.kubernetes.io/last-applied-configuration annotation which is
    required by oc apply. oc apply should only b e used on resources created
    declaratively by either oc create --save-config or oc apply. The missing
    annotation will be patched automatically.
    pattern.gitops.hybrid-cloud-patterns.io/multicloud-gitops configured
    Warning: resource subscriptions/patterns-operator is missing the
    kubectl.kubernetes.io/last-applied-configuration annotation which is
    required by oc apply. oc apply should o nly be used on resources created
    declaratively by either oc create --save-config or oc apply. The missing
    annotation will be patched automatically.
    subscription.operators.coreos.com/patterns-operator configured

Tested by installing a pattern via UI of the VP Operator, then locally ran
`make install` and observed the new git branch being applied in the
operator.