### PR TITLE
Switch to ansible-automation-platform-23/ee-supported-rhel8:latest image by default

### DIFF
--- a/clustergroup/values.yaml
+++ b/clustergroup/values.yaml
@@ -17,7 +17,7 @@ clusterGroup:
   imperative:
     jobs: []
     # This image contains ansible + kubernetes.core by default and is used to run the jobs
-    image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+    image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
     namespace: "imperative"
     # configmap name in the namespace that will contain all helm values
     valuesConfigMap: "helm-values-configmap"

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -88,7 +88,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
         imagePullPolicy: Always
         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
         jobName: imperative-job
@@ -284,7 +284,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -297,7 +297,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: test
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -320,7 +320,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -209,7 +209,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
         imagePullPolicy: Always
         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
         jobName: imperative-job
@@ -445,7 +445,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -458,7 +458,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: test
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -481,7 +481,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'
@@ -519,7 +519,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -532,7 +532,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: unseal-playbook
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -557,7 +557,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -220,7 +220,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
         imagePullPolicy: Always
         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
         jobName: imperative-job
@@ -432,7 +432,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -445,7 +445,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: test
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -468,7 +468,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'
@@ -506,7 +506,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -519,7 +519,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: unseal-playbook
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -544,7 +544,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -43,7 +43,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
         imagePullPolicy: Always
         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
         jobName: imperative-job
@@ -199,7 +199,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -212,7 +212,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: unseal-playbook
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -237,7 +237,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -76,7 +76,7 @@ data:
         clusterRoleName: imperative-cluster-role
         clusterRoleYaml: ""
         cronJobName: imperative-cronjob
-        image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+        image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
         imagePullPolicy: Always
         insecureUnsealVaultInsideClusterSchedule: '*/5 * * * *'
         jobName: imperative-job
@@ -314,7 +314,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -327,7 +327,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: test
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -350,7 +350,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'
@@ -388,7 +388,7 @@ spec:
             # git init happens in /git/repo so that we can set the folder to 0770 permissions
             # reason for that is ansible refuses to create temporary folders in there            
             - name: git-init
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -401,7 +401,7 @@ spec:
               - name: git
                 mountPath: "/git"
             - name: unseal-playbook
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               env:
                 - name: HOME
@@ -426,7 +426,7 @@ spec:
                   subPath: values.yaml
           containers:            
             - name: "done"
-              image: registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+              image: registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest
               imagePullPolicy: Always
               command:
                 - 'sh'


### PR DESCRIPTION
We want to stay up-to-date as to what image containing ansible we use.
https://catalog.redhat.com/software/containers/ansible-automation-platform-23/ee-supported-rhel8/62c7060bc1d77e67d5893a78

This image contains ansible 2.14.3 and kubernetes.cor 2.3.2:

    $ podman run -it --rm --net=host --entrypoint /bin/bash registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest -c "ansible-galaxy collection list|grep kubern"
    kubernetes.core         2.3.2

Tested on an MCG deployment
