### PR TITLE
Bug: Fix for extraValueFiles in Application template

### DIFF
--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -60,7 +60,7 @@ spec:
             - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
             {{- end }}
         {{- range .extraValueFiles }}
-            - {{ . | quote }}
+            - /{{ . | quote }}
         {{- end }}
         {{- if .useGeneratorValues }}
           values: |-
@@ -162,7 +162,7 @@ spec:
       - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
       {{- end }}
       {{- range $valueFile := .extraValueFiles }}
-      - {{ $valueFile | quote }}
+      - /{{ $valueFile | quote }}
       {{- end }}
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:

--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -60,7 +60,7 @@ spec:
             - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
             {{- end }}
         {{- range .extraValueFiles }}
-            - /{{ . | quote }}
+            - "/{{ . }}"
         {{- end }}
         {{- if .useGeneratorValues }}
           values: |-
@@ -162,7 +162,7 @@ spec:
       - "/values-{{ $.Values.global.clusterVersion }}-{{ $.Values.clusterGroup.name }}.yaml"
       {{- end }}
       {{- range $valueFile := .extraValueFiles }}
-      - /{{ $valueFile | quote }}
+      - "/{{ $valueFile }}"
       {{- end }}
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:

--- a/examples/values-example.yaml
+++ b/examples/values-example.yaml
@@ -53,6 +53,14 @@ clusterGroup:
       project: datacenter
       path: charts/datacenter/pipelines
 
+    xyz:
+      name: xyz-chart
+      namespace: xyz
+      project: hub
+      path: charts/mgt-hub/xyz
+      extraValueFiles:
+      - values-myxyz.yaml
+
   imperative:
     namespace: imperative
     # NOTE: We *must* use lists and not hashes. As hashes lose ordering once parsed by helm

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -617,7 +617,7 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-example.yaml"
-      - /"values-myxyz.yaml"
+      - "/values-myxyz.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -71,6 +71,13 @@ data:
           namespace: application-ci
           path: charts/datacenter/pipelines
           project: datacenter
+        xyz:
+          extraValueFiles:
+          - values-myxyz.yaml
+          name: xyz-chart
+          namespace: xyz
+          path: charts/mgt-hub/xyz
+          project: hub
       imperative:
         activeDeadlineSeconds: 3600
         clusterRoleName: imperative-cluster-role
@@ -564,6 +571,53 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-example.yaml"
+      # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
+      parameters:
+        - name: global.repoURL
+          value: $ARGOCD_APP_SOURCE_REPO_URL
+        - name: global.targetRevision
+          value: $ARGOCD_APP_SOURCE_TARGET_REVISION
+        - name: global.namespace
+          value: $ARGOCD_APP_NAMESPACE
+        - name: global.pattern
+          value: mypattern
+        - name: global.clusterDomain
+          value: region.example.com
+        - name: global.clusterVersion
+          value: ""
+        - name: global.clusterPlatform
+          value: ""
+        - name: global.hubClusterDomain
+          value: apps.hub.example.com
+        - name: global.localClusterDomain
+          value: apps.region.example.com
+  syncPolicy:
+    automated: {}
+    #  selfHeal: true
+---
+# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: xyz-chart
+  namespace: mypattern-example
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  destination:
+    name: in-cluster
+    namespace: xyz
+  project: hub
+  source:
+    repoURL: https://github.com/pattern-clone/mypattern
+    targetRevision: main
+    path: charts/mgt-hub/xyz
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+      - "/values-global.yaml"
+      - "/values-example.yaml"
+      - /"values-myxyz.yaml"
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL


### PR DESCRIPTION
When you define the xyz chart application in the **applications:** section of the values-hub.yaml like so:
```
xyz:
      name: xyz-chart
      namespace: xyz
      project: hub
      path: charts/mgt-hub/xyz
      extraValueFiles:
      - values-myxyz.yaml
```
What we generate is the following Application manifest for ArgoCD to consume:
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: xyz-chart
  namespace: common-example
  finalizers:
  - resources-finalizer.argocd.argoproj.io/foreground
spec:
  destination:
    name: in-cluster
    namespace: xyz
  project: hub
  source:
    repoURL: 
    targetRevision: main
    path: charts/mgt-hub/xyz
    helm:
      ignoreMissingValueFiles: true
      valueFiles:
      - "/values-global.yaml"
      - "/values-example.yaml"
      - "values-myxyz.yaml"  <============ Is this supposed to be /values-myxyz.yaml?
      # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
      parameters:
        - name: global.repoURL
          value: $ARGOCD_APP_SOURCE_REPO_URL
...
  syncPolicy:
    automated: {}
    #  selfHeal: true
```

This fix will generate the valuesFiles section with the '/' at the beginning of the values file:

```
      valueFiles:
      - "/values-global.yaml"
      - "/values-example.yaml"
      - "/values-myxyz.yaml"  <============ Generated as /values-myxyz.yaml
```