### PR TITLE
Do not apply the ocp-gitops-policy on the hub via ACM

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Apr 11, 2023
+
+* Apply the ACM ocp-gitops-policy everywhere but the hub
+
 ## Apr 7, 2023
 
 * Moved to gitops-1.8 channel by default (stable is unmaintained and will be dropped starting with ocp-4.13)

--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -76,3 +76,7 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'

--- a/tests/acm-industrial-edge-factory.expected.yaml
+++ b/tests/acm-industrial-edge-factory.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -121,6 +121,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -112,6 +112,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -530,6 +530,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
The subscription for the gitops policy is controlled by the operator.
If a user changes the gitops subscription channel via the operator,
ACM will actually override this and push its own channel.

Tested via MCG:
* Before the fix
1. Installed the hub via the UI and chose "stable" as the gitops channel
2. Observed that once ACM started applying policies the gitops
   subscription was "upgraded" to gitops-1.8

* After the fix
1. Installed the hub via the UI and chose "stable" as the gitops channel
2. Observed that once ACM started applying policies the gitops
   subscription stayed the same on the hub
