### PR TITLE
Do not hardcode the gitops version that gets installed on spokes

### DIFF
--- a/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/acm/templates/policies/ocp-gitops-policy.yaml
@@ -35,7 +35,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: gitops-1.8
+                  channel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -1,3 +1,7 @@
+main:
+  gitops:
+    channel: "gitops-1.8"
+
 global:
   pattern: none
   repoURL: none


### PR DESCRIPTION
Let's derive it from main.gitops.channel just like we do in other
places.

Tested on an MCG hub/spoke setup and set the following values:

    main:
      gitops:
        channel: "gitops-1.7"

Correctly observed gitops-1.7 installed on both hub and cluster
