### PR TITLE
Fix up kustomize example

### DIFF
--- a/examples/kustomize-renderer/kustomize
+++ b/examples/kustomize-renderer/kustomize
@@ -5,11 +5,10 @@ if [ $BASE = $PWD ]; then
     BASE=./
 fi
 
-cat <&0 > "$BASE/helm.patch.yaml"
+cat <&0 > "$BASE/helm.yaml"
 
 # Including at least one log to stderr allows us to see the full -x output
 echo $HOME $PWD 1>&2
 ls -al  1>&2
 
-kubectl kustomize "$BASE" && rm "$BASE/helm.patch.yaml" 
-#kubectl kustomize "$BASE" > "$BASE/result.yaml"
+kustomize build "$BASE" && rm "$BASE/helm.yaml"


### PR DESCRIPTION
In the same vein as Industrial Edge 57f41dc135f72011d3796fe42d9cbf05d2b82052
we call kustomize build.

Newer gitops versions dropped the openshift-clients rpm by default which
contained kubectl. Let's just invoke "kustomize" directly as the binary
is present in both old and new gitops versions

Since "kubectl kustomize" builds the set of resources by default, we
need to switch to "kubectl build" by default

We also use the same naming conventions used in Industrial Edge while
we're at it.
