### PR TITLE
Added health check for pvc resource in argocd.yaml

### DIFF
--- a/clustergroup/templates/plumbing/argocd.yaml
+++ b/clustergroup/templates/plumbing/argocd.yaml
@@ -24,8 +24,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/clustergroup/templates/plumbing/argocd.yaml
+++ b/clustergroup/templates/plumbing/argocd.yaml
@@ -12,6 +12,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |

--- a/clustergroup/templates/plumbing/argocd.yaml
+++ b/clustergroup/templates/plumbing/argocd.yaml
@@ -12,6 +12,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -443,6 +443,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -443,6 +443,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -455,8 +455,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -1076,6 +1076,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -1088,8 +1088,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -1076,6 +1076,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -1264,8 +1264,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -1252,6 +1252,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -1252,6 +1252,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -266,6 +266,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -278,8 +278,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -266,6 +266,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -853,8 +853,7 @@ spec:
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs
-            end
-            if obj.status.phase == "Bound" then
+            elseif obj.status.phase == "Bound" then
               hs.status = "Healthy"
               hs.message = obj.status.phase
               return hs

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -841,6 +841,27 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+  resourceCustomizations: |
+    PersistentVolumeClaim:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            if obj.status.phase == "Pending" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+            if obj.status.phase == "Bound" then
+              hs.status = "Healthy"
+              hs.message = obj.status.phase
+              return hs
+            end
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Waiting for PVC"
+        return hs
   applicationInstanceLabelKey: argocd.argoproj.io/instance
   # Not the greatest way to pass git/quay info to sub-applications, but it will do until
   # we can support helmChart with kustomize

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -841,6 +841,8 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
+# Adding health checks to argocd to prevent pvc resources
+# that aren't bound state from blocking deployments
   resourceCustomizations: |
     PersistentVolumeClaim:
       health.lua: |


### PR DESCRIPTION
This allows argo to continue rolling out the rest of the applications whenever a PVC is in a pending status, which presents a chicken/egg scenario for a deployment/deploymentConfig depending on that PVC.  The storageclass bindingmode is `WaitForFirstConsumer` in the hyperscalers, and to override this we would either need to make a separate storageclass with `Immediate` volumebinding and change the order of deployment.

With health check implemented, when the pvc is pending, bound it is considered healthy, and when it reports an error will show as unhealthy. 

Without the health check the application is stuck in a progressing state and will not continue thus preventing any downstream application from deploying.

This directly affects devsecops because we create a pvc for when the pipeline runs, which is `n` minutes/hours/days after deployment. However, all other patterns are affected that create a PVC and Deployment/DeploymentConfig in separate manifests. 