### PR TITLE
Improve the grepping for the operator bundle

### DIFF
--- a/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
+++ b/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
@@ -67,7 +67,7 @@
 - name: Get bundle image
   ansible.builtin.shell: |
     set -o pipefail
-    podman run -it --rm "{{ iib_image }}" alpha list bundles /configs "{{ item }}" | grep --word-regexp "{{ bundle_channel }}" | awk '{ print $NF }'
+    podman run -it --rm "{{ iib_image }}" alpha list bundles /configs "{{ item }}" | grep -e "{{ default_channel }}\s\+{{ bundle_channel }}" | awk '{ print $NF }'
   register: bundle_image_raw
 
 - name: Set bundle image fact


### PR DESCRIPTION
Without also grepping for the default_channel we can end up getting
multiple results, which breaks everything.

Tested this and it fixed the issue I was seeing with the
openshift-gitops-operator this morning
