### PR TITLE
Drop display_skipped_hosts

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-display_skipped_hosts=False
 localhost_warning=False
 library=./plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles


### PR DESCRIPTION
display_skipped_hosts=False has a horrible side-effect:
When a task takes a long time, it is always the *next* task and not the
one printed on the screen/log. That is because ansible has to wait for
the task to finish before printing it as it does not know before hand if
the host will be skipped and hence the task should not be displayed at
all
