### PR TITLE
Drop https:// from podman login

### DIFF
--- a/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
+++ b/ansible/roles/iib_ci/tasks/setup-internal-registry.yml
@@ -97,7 +97,7 @@
 
 - name: Login the internal registry with podman
   ansible.builtin.command:
-    podman login --tls-verify=false --username unused --password "{{ kubeadmin_token }}" "https://{{ registry_route }}"
+    podman login --tls-verify=false --username unused --password "{{ kubeadmin_token }}" "{{ registry_route }}"
 
 - name: Set Mirror URL fact for internal mirror IIB
   ansible.builtin.set_fact:


### PR DESCRIPTION
Seems we hit https://www.github.com/containers/podman/issues/13691 at
least with older podman versions.

If this turns out to break podman 4.5.0 I will special case it later
