### PR TITLE
Set the mce-subscription-spec annotation

### DIFF
--- a/acm/templates/multiclusterhub.yaml
+++ b/acm/templates/multiclusterhub.yaml
@@ -5,4 +5,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    {{- if kindIs "map" .Values.clusterGroup.subscriptions }}
+    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "{{ default "redhat-operators" .Values.clusterGroup.subscriptions.acm.source }}" }'
+    {{- end }}
 spec: {}

--- a/acm/values.yaml
+++ b/acm/values.yaml
@@ -9,6 +9,9 @@ global:
 
 
 clusterGroup:
+  subscriptions:
+    acm:
+      source: redhat-operators
   managedClusterGroups:
 #    testRegion:
 #      name: region-one

--- a/tests/acm-industrial-edge-hub.expected.yaml
+++ b/tests/acm-industrial-edge-hub.expected.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "redhat-operators" }'
 spec: {}
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml

--- a/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "redhat-operators" }'
 spec: {}
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml

--- a/tests/acm-naked.expected.yaml
+++ b/tests/acm-naked.expected.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "redhat-operators" }'
 spec: {}
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -399,6 +399,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "redhat-operators" }'
 spec: {}
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml


### PR DESCRIPTION
We set it by default to "redhat-operators" and if defined to .Values.clusterGroup.subscriptions.acm.source
The reason we do this is the following:
1. In a default deployment scenario MCE has to be deployed as normal
   from the redhat-operators catalogSource just as ACM is
2. When we deploy gitops-operator from an IIB instead, MCE would be
   installed trying to get it from the IIB because
   https://www.github.com/stolostron/multiclusterhub-operator/pull/975
   made it so that it picks the latest version looking at all catalog
   sources. But since we only mirrored the gitops operator in the
   cluster, this breaks as the images for MCE from the IIB are not there
   By setting the default to "redhat-operators" we fix this case
3. Now in the case where we want to install ACM from an IIB we need to
   be able to override this and we will pick whatever value is set in
   .Values.clusterGroup.subscriptions.acm.source, which will need to be
   defined for this to work when testing ACM+MCE from an IIB

Note: Currently point 3. works only if you set it in a values file.
Setting .Values.clusterGroup.subscriptions.acm.source via extraParams
won't be passed down from the clusterGroup app to the applications.
It's a bug that we need to fix.

Note(2): We surround this with an 'if kindIs "map" .Values.clusterGroup.subscriptions'
because we do not want to break things if subscription is a list and not
a map. If we ever manage to drop subscriptions as list, then we can
remove that if
