### PR TITLE
Add support for extraParams being passed down to all applications

### DIFF
--- a/clustergroup/templates/plumbing/applications.yaml
+++ b/clustergroup/templates/plumbing/applications.yaml
@@ -111,6 +111,10 @@ spec:
             - name: {{ . }}
               value: {{ $.Values.global.pattern }}
         {{- end }}
+        {{- range $k, $v := $.Values.extraParametersNested }}
+            - name: {{ $k }}
+              value: {{ $v }}
+        {{- end }}
         {{- range .overrides }}
             - name: {{ .name  }}
               value: {{ .value | quote  }}
@@ -207,6 +211,10 @@ spec:
         {{- range .extraPatternNameFields }}
         - name: {{ . }}
           value: {{ $.Values.global.pattern }}
+        {{- end }}
+        {{- range $k, $v := $.Values.extraParametersNested }}
+        - name: {{ $k }}
+          value: {{ $v }}
         {{- end }}
         {{- range .overrides }}
         - name: {{ .name }}


### PR DESCRIPTION
Via https://github.com/hybrid-cloud-patterns/patterns-operator/pull/74
we add the extraParams in an extraParametersNested dictionary that holds
the extraParams key/value pairs. If they exist, let's add them as
parameters.

This allows them to end up in the applications.
