### PR TITLE
Allow overriding channel and source when installing the patterns-operator

### DIFF
--- a/operator-install/templates/subscription.yaml
+++ b/operator-install/templates/subscription.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     operators.coreos.com/patterns-operator.openshift-operators: ""
 spec:
-  channel: fast
+  channel: {{ .Values.main.patternsOperator.channel }}
   installPlanApproval: Automatic
   name: patterns-operator
-  source: community-operators
+  source: {{ .Values.main.patternsOperator.source }}
   sourceNamespace: openshift-marketplace

--- a/operator-install/values.yaml
+++ b/operator-install/values.yaml
@@ -7,4 +7,8 @@ main:
     channel: "gitops-1.8"
     operatorSource: redhat-operators
 
+  patternsOperator:
+    channel: fast
+    source: community-operators
+
   clusterGroupName: default


### PR DESCRIPTION
This will allow us to test the patterns-operator using a different
catalogsource (potentially installed via an IIB). So we can run:

make EXTRA_HELM_OPTS="\
  --set main.extraParameters[0].name=main.patternsOperator.channel --set main.extraParameters[0].value=slow \
  --set main.extraParameters[1].name=main.patternsOperator.source --set main.extraParameters[1].value=patten-index" install
