### PR TITLE
Tweak the load secret debug message to be clearer

### DIFF
--- a/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -80,9 +80,12 @@
   register: encrypted
   failed_when: (encrypted.rc not in [0, 1])
 
+# When HOME is set we replace it with '~' in this debug message
+# because when run from inside the container the HOME is /pattern-home
+# which is confusing for users
 - name: Is found values secret file encrypted
   ansible.builtin.debug:
-    msg: "Using {{ found_file }} to parse secrets"
+    msg: "Using {{ (lookup('env', 'HOME') | length > 0) | ternary(found_file | regex_replace('^' + lookup('env', 'HOME'), '~'), found_file) }} to parse secrets"
 
 - name: Set encryption bool fact
   no_log: true


### PR DESCRIPTION
When HOME is set we replace it with '~' in this debug message
because when run from inside the container the HOME is /pattern-home
which is confusing for users. Printing out '~' when at the start of
the string is less confusing.

Before:
ok: [localhost] => {
    "msg": "/home/michele/.config/hybrid-cloud-patterns/values-secret-multicloud-gitops.yaml"
}

After:
ok: [localhost] => {
    "msg": "~/.config/hybrid-cloud-patterns/values-secret-multicloud-gitops.yaml"
}
