### PR TITLE
Check if the KUBECONFIG file is inside /tmp

### DIFF
--- a/scripts/pattern-util.sh
+++ b/scripts/pattern-util.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
@@ -14,6 +14,13 @@ for i in ${UNSUPPORTED_PODMAN_VERSIONS}; do
 	fi
 done
 
+if [ -n "$KUBECONFIG" ]; then
+    if [[ ! "${KUBECONFIG}" =~ ^$HOME* ]]; then
+        echo "${KUBECONFIG} is pointing outside of the HOME folder, this will make it unavailable from the container."
+        echo "Please move it somewhere inside your $HOME folder, as that is what gets bind-mounted inside the container"
+        exit 1
+    fi
+fi
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials


### PR DESCRIPTION
If it is somewhere under /tmp, bail out explaining why. This has caused
a few silly situations where the user would save the KUBECONFIG file
under /tmp. Since bind-mounting /tmp seems like a wrong thing to do in
general, we at least bail out with a clear error message.
To do this we rely on a bash functionality so let's just switch the
script to use that.

Tested as follows:
export KUBECONFIG=/tmp/kubeconfig
./scripts/pattern-util.sh make help
/tmp/kubeconfig is pointing inside the /tmp folder, this will make it unavailable from the container.
Please move it somewhere inside your /home/michele folder, as that gets bind-mounted inside the container

export KUBECONFIG=~/kubeconfig
./scripts/pattern-util.sh make help
Pattern: common

Usage:
  make <target>
...
