### PR TITLE
Clustergroup Chart.yaml name change

### DIFF
--- a/clustergroup/Chart.yaml
+++ b/clustergroup/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: A Helm chart to create per-clustergroup ArgoCD applications and any required namespaces or subscriptions
 keywords:
 - pattern
-name: pattern-clustergroup
+name: clustergroup
 version: 0.0.1

--- a/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,7 +8,7 @@ metadata:
   name: manuela-stormshift-line-dashboard
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,7 +17,7 @@ metadata:
   name: manuela-stormshift-machine-sensor
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ metadata:
   name: manuela-stormshift-messaging
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -35,7 +35,7 @@ metadata:
   name: manuela-factory-ml-workspace
 spec:
 ---
-# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+# Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -44,7 +44,7 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-factory
   name: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+# Source: clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -57,14 +57,14 @@ metadata:
   name: mypattern-factory
 spec: {}
 ---
-# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+# Source: clustergroup/templates/imperative/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imperative-sa
   namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+# Source: clustergroup/templates/imperative/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -161,7 +161,7 @@ data:
       kind: ClusterSecretStore
       name: vault-backend
 ---
-# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+# Source: clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -176,7 +176,7 @@ rules:
     - list
     - watch
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -190,7 +190,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -209,7 +209,7 @@ subjects:
     name: openshift-gitops-argocd-server
     namespace: openshift-gitops
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -234,7 +234,7 @@ subjects:
     name: factory-gitops-argocd-dex-server
     namespace: mypattern-factory
 ---
-# Source: pattern-clustergroup/templates/imperative/role.yaml
+# Source: clustergroup/templates/imperative/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -248,7 +248,7 @@ rules:
     verbs:
     - '*'
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -263,7 +263,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/job.yaml
+# Source: clustergroup/templates/imperative/job.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -337,10 +337,10 @@ spec:
               name: helm-values-configmap-factory
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 ---
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -361,7 +361,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -386,7 +386,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -432,7 +432,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
@@ -569,7 +569,7 @@ spec:
     ca: {}
 status:
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
@@ -583,7 +583,7 @@ spec:
   location: ApplicationMenu
   text: 'Factory ArgoCD'
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -593,7 +593,7 @@ spec:
   targetNamespaces:
   - manuela-stormshift-line-dashboard
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -603,7 +603,7 @@ spec:
   targetNamespaces:
   - manuela-stormshift-machine-sensor
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -613,7 +613,7 @@ spec:
   targetNamespaces:
   - manuela-stormshift-messaging
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -627,7 +627,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -641,7 +641,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -655,7 +655,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -669,7 +669,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,7 +8,7 @@ metadata:
   name: golang-external-secrets
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,7 +17,7 @@ metadata:
   name: external-secrets
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ metadata:
   name: open-cluster-management
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -35,7 +35,7 @@ metadata:
   name: manuela-ml-workspace
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -44,7 +44,7 @@ metadata:
   name: manuela-tst-all
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -53,7 +53,7 @@ metadata:
   name: manuela-ci
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -62,7 +62,7 @@ metadata:
   name: manuela-data-lake
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -71,7 +71,7 @@ metadata:
   name: staging
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -80,7 +80,7 @@ metadata:
   name: vault
 spec:
 ---
-# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+# Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -89,7 +89,7 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-datacenter
   name: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+# Source: clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -102,14 +102,14 @@ metadata:
   name: mypattern-datacenter
 spec: {}
 ---
-# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+# Source: clustergroup/templates/imperative/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imperative-sa
   namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+# Source: clustergroup/templates/imperative/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -322,7 +322,7 @@ data:
       kind: ClusterSecretStore
       name: vault-backend
 ---
-# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+# Source: clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -337,7 +337,7 @@ rules:
     - list
     - watch
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -351,7 +351,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -370,7 +370,7 @@ subjects:
     name: openshift-gitops-argocd-server
     namespace: openshift-gitops
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -395,7 +395,7 @@ subjects:
     name: datacenter-gitops-argocd-dex-server
     namespace: mypattern-datacenter
 ---
-# Source: pattern-clustergroup/templates/imperative/role.yaml
+# Source: clustergroup/templates/imperative/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -409,7 +409,7 @@ rules:
     verbs:
     - '*'
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -424,7 +424,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/job.yaml
+# Source: clustergroup/templates/imperative/job.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -498,7 +498,7 @@ spec:
               name: helm-values-configmap-datacenter
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+# Source: clustergroup/templates/imperative/unsealjob.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -574,10 +574,10 @@ spec:
               name: helm-values-configmap-datacenter
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 ---
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -598,7 +598,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -619,7 +619,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -640,7 +640,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -661,7 +661,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -716,7 +716,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -762,7 +762,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -808,7 +808,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -884,7 +884,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -930,7 +930,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -976,7 +976,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1001,7 +1001,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1065,7 +1065,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
@@ -1202,7 +1202,7 @@ spec:
     ca: {}
 status:
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
@@ -1216,7 +1216,7 @@ spec:
   location: ApplicationMenu
   text: 'Datacenter ArgoCD'
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1226,7 +1226,7 @@ spec:
   targetNamespaces:
   - golang-external-secrets
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1236,7 +1236,7 @@ spec:
   targetNamespaces:
   - external-secrets
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1246,7 +1246,7 @@ spec:
   targetNamespaces:
   - open-cluster-management
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1256,7 +1256,7 @@ spec:
   targetNamespaces:
   - manuela-tst-all
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1266,7 +1266,7 @@ spec:
   targetNamespaces:
   - manuela-ci
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1276,7 +1276,7 @@ spec:
   targetNamespaces:
   - manuela-data-lake
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1286,7 +1286,7 @@ spec:
   targetNamespaces:
   - staging
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1296,7 +1296,7 @@ spec:
   targetNamespaces:
   - vault
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1310,7 +1310,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1324,7 +1324,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1338,7 +1338,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1352,7 +1352,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1366,7 +1366,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1380,7 +1380,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1394,7 +1394,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1408,7 +1408,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1422,7 +1422,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,7 +8,7 @@ metadata:
   name: open-cluster-management
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,7 +17,7 @@ metadata:
   name: openshift-serverless
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ metadata:
   name: opendatahub
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -35,7 +35,7 @@ metadata:
   name: openshift-storage
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -44,7 +44,7 @@ metadata:
   name: xraylab-1
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -53,7 +53,7 @@ metadata:
   name: knative-serving
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -62,7 +62,7 @@ metadata:
   name: staging
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -71,7 +71,7 @@ metadata:
   name: vault
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -80,7 +80,7 @@ metadata:
   name: golang-external-secrets
 spec:
 ---
-# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+# Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -89,7 +89,7 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-hub
   name: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+# Source: clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -102,14 +102,14 @@ metadata:
   name: mypattern-hub
 spec: {}
 ---
-# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+# Source: clustergroup/templates/imperative/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imperative-sa
   namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+# Source: clustergroup/templates/imperative/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -309,7 +309,7 @@ data:
       kind: ClusterSecretStore
       name: vault-backend
 ---
-# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+# Source: clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -324,7 +324,7 @@ rules:
     - list
     - watch
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -338,7 +338,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -357,7 +357,7 @@ subjects:
     name: openshift-gitops-argocd-server
     namespace: openshift-gitops
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -382,7 +382,7 @@ subjects:
     name: hub-gitops-argocd-dex-server
     namespace: mypattern-hub
 ---
-# Source: pattern-clustergroup/templates/imperative/role.yaml
+# Source: clustergroup/templates/imperative/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -396,7 +396,7 @@ rules:
     verbs:
     - '*'
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -411,7 +411,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/job.yaml
+# Source: clustergroup/templates/imperative/job.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -485,7 +485,7 @@ spec:
               name: helm-values-configmap-hub
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+# Source: clustergroup/templates/imperative/unsealjob.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -561,10 +561,10 @@ spec:
               name: helm-values-configmap-hub
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 ---
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -585,7 +585,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -606,7 +606,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -652,7 +652,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -698,7 +698,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -744,7 +744,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -790,7 +790,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -836,7 +836,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -882,7 +882,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -928,7 +928,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -992,7 +992,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1038,7 +1038,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1084,7 +1084,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1139,7 +1139,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1194,7 +1194,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -1240,7 +1240,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
@@ -1377,7 +1377,7 @@ spec:
     ca: {}
 status:
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
@@ -1391,7 +1391,7 @@ spec:
   location: ApplicationMenu
   text: 'Hub ArgoCD'
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1401,7 +1401,7 @@ spec:
   targetNamespaces:
   - open-cluster-management
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1411,7 +1411,7 @@ spec:
   targetNamespaces:
   - openshift-serverless
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1421,7 +1421,7 @@ spec:
   targetNamespaces:
   - opendatahub
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1431,7 +1431,7 @@ spec:
   targetNamespaces:
   - openshift-storage
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1441,7 +1441,7 @@ spec:
   targetNamespaces:
   - xraylab-1
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1451,7 +1451,7 @@ spec:
   targetNamespaces:
   - knative-serving
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1461,7 +1461,7 @@ spec:
   targetNamespaces:
   - staging
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1471,7 +1471,7 @@ spec:
   targetNamespaces:
   - vault
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1481,7 +1481,7 @@ spec:
   targetNamespaces:
   - golang-external-secrets
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1495,7 +1495,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1509,7 +1509,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1523,7 +1523,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1536,7 +1536,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV:
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/tests/clustergroup-naked.expected.yaml
+++ b/tests/clustergroup-naked.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+# Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/managed-by: common-example
   name: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+# Source: clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -21,14 +21,14 @@ metadata:
   name: common-example
 spec: {}
 ---
-# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+# Source: clustergroup/templates/imperative/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imperative-sa
   namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+# Source: clustergroup/templates/imperative/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -76,7 +76,7 @@ data:
       kind: ClusterSecretStore
       name: vault-backend
 ---
-# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+# Source: clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -91,7 +91,7 @@ rules:
     - list
     - watch
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -105,7 +105,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -124,7 +124,7 @@ subjects:
     name: openshift-gitops-argocd-server
     namespace: openshift-gitops
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -149,7 +149,7 @@ subjects:
     name: example-gitops-argocd-dex-server
     namespace: common-example
 ---
-# Source: pattern-clustergroup/templates/imperative/role.yaml
+# Source: clustergroup/templates/imperative/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -163,7 +163,7 @@ rules:
     verbs:
     - '*'
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -178,7 +178,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+# Source: clustergroup/templates/imperative/unsealjob.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -254,7 +254,7 @@ spec:
               name: helm-values-configmap-example
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
@@ -391,7 +391,7 @@ spec:
     ca: {}
 status:
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:

--- a/tests/clustergroup-normal.expected.yaml
+++ b/tests/clustergroup-normal.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -13,7 +13,7 @@ metadata:
     owner: "namespace owner"
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -22,7 +22,7 @@ metadata:
   name: application-ci
 spec:
 ---
-# Source: pattern-clustergroup/templates/core/namespaces.yaml
+# Source: clustergroup/templates/core/namespaces.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -31,7 +31,7 @@ metadata:
   name: excludes-ci
 spec:
 ---
-# Source: pattern-clustergroup/templates/imperative/namespace.yaml
+# Source: clustergroup/templates/imperative/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -40,7 +40,7 @@ metadata:
     argocd.argoproj.io/managed-by: mypattern-example
   name: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/gitops-namespace.yaml
+# Source: clustergroup/templates/plumbing/gitops-namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -53,14 +53,14 @@ metadata:
   name: mypattern-example
 spec: {}
 ---
-# Source: pattern-clustergroup/templates/imperative/serviceaccount.yaml
+# Source: clustergroup/templates/imperative/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imperative-sa
   namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/configmap.yaml
+# Source: clustergroup/templates/imperative/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -219,7 +219,7 @@ data:
       kind: ClusterSecretStore
       name: vault-backend
 ---
-# Source: pattern-clustergroup/templates/imperative/clusterrole.yaml
+# Source: clustergroup/templates/imperative/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -234,7 +234,7 @@ rules:
     - list
     - watch
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -248,7 +248,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -267,7 +267,7 @@ subjects:
     name: openshift-gitops-argocd-server
     namespace: openshift-gitops
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd-super-role.yaml
+# Source: clustergroup/templates/plumbing/argocd-super-role.yaml
 # WARNING: ONLY USE THIS FOR MANAGING CLUSTERS NOT FOR REGULAR USERS
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -292,7 +292,7 @@ subjects:
     name: example-gitops-argocd-dex-server
     namespace: mypattern-example
 ---
-# Source: pattern-clustergroup/templates/imperative/role.yaml
+# Source: clustergroup/templates/imperative/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -306,7 +306,7 @@ rules:
     verbs:
     - '*'
 ---
-# Source: pattern-clustergroup/templates/imperative/rbac.yaml
+# Source: clustergroup/templates/imperative/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -321,7 +321,7 @@ subjects:
     name: imperative-sa
     namespace: imperative
 ---
-# Source: pattern-clustergroup/templates/imperative/job.yaml
+# Source: clustergroup/templates/imperative/job.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -395,7 +395,7 @@ spec:
               name: helm-values-configmap-example
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/imperative/unsealjob.yaml
+# Source: clustergroup/templates/imperative/unsealjob.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -471,10 +471,10 @@ spec:
               name: helm-values-configmap-example
           restartPolicy: Never
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 ---
 ---
-# Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml
+# Source: clustergroup/templates/plumbing/hosted-sites.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -495,7 +495,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/projects.yaml
+# Source: clustergroup/templates/plumbing/projects.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -516,7 +516,7 @@ spec:
   - '*'
 status: {}
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -571,7 +571,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/applications.yaml
+# Source: clustergroup/templates/plumbing/applications.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -617,7 +617,7 @@ spec:
     retry:
       limit: 20
 ---
-# Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml
+# Source: clustergroup/templates/plumbing/hosted-sites.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -677,7 +677,7 @@ spec:
     jsonPointers:
     - /status
 ---
-# Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml
+# Source: clustergroup/templates/plumbing/hosted-sites.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -737,7 +737,7 @@ spec:
     jsonPointers:
     - /status
 ---
-# Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml
+# Source: clustergroup/templates/plumbing/hosted-sites.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -797,7 +797,7 @@ spec:
     jsonPointers:
     - /status
 ---
-# Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml
+# Source: clustergroup/templates/plumbing/hosted-sites.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -857,7 +857,7 @@ spec:
     jsonPointers:
     - /status
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
@@ -994,7 +994,7 @@ spec:
     ca: {}
 status:
 ---
-# Source: pattern-clustergroup/templates/plumbing/argocd.yaml
+# Source: clustergroup/templates/plumbing/argocd.yaml
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
@@ -1008,7 +1008,7 @@ spec:
   location: ApplicationMenu
   text: 'Example ArgoCD'
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1018,7 +1018,7 @@ spec:
   targetNamespaces:
   - open-cluster-management
 ---
-# Source: pattern-clustergroup/templates/core/operatorgroup.yaml
+# Source: clustergroup/templates/core/operatorgroup.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -1028,7 +1028,7 @@ spec:
   targetNamespaces:
   - application-ci
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -1042,7 +1042,7 @@ spec:
   installPlanApproval: Automatic
   startingCSV: advanced-cluster-management.v2.4.1
 ---
-# Source: pattern-clustergroup/templates/core/subscriptions.yaml
+# Source: clustergroup/templates/core/subscriptions.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
We currently have a small inconsistency where we use common/clustergroup
in order to point Argo CD to this chart, but the name inside the chart
is 'pattern-clustergroup'.

This inconsistency is currently irrelevant, but in the future when
migrating to helm charts inside proper helm repos, this becomes
problematic. So let's fix the name to be the same as the folder.

Tested on MCG successfully.
