### PR TITLE
Fix the clusterPoolName in clusterClaims

### DIFF
--- a/acm/templates/provision/clusterpool.yaml
+++ b/acm/templates/provision/clusterpool.yaml
@@ -87,7 +87,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  clusterPoolName: {{ $pool.name }}
+  clusterPoolName: {{ $poolName }}
 ---
 {{- end }}{{- /* range .range clusters */}}
 {{- end }}{{- /* range .clusterPools */}}

--- a/tests/acm-normal.expected.yaml
+++ b/tests/acm-normal.expected.yaml
@@ -35,7 +35,7 @@ metadata:
     clusterClaimName: two-acm-provision-edge
     clusterGroup: region
 spec:
-  clusterPoolName: azure-us
+  clusterPoolName: azure-us-acm-provision-edge
 ---
 # Source: acm/templates/provision/clusterpool.yaml
 apiVersion: hive.openshift.io/v1
@@ -50,7 +50,7 @@ metadata:
     clusterClaimName: three-acm-provision-edge
     clusterGroup: region
 spec:
-  clusterPoolName: azure-us
+  clusterPoolName: azure-us-acm-provision-edge
 ---
 # Source: acm/templates/provision/clusterpool.yaml
 apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
Currently with the following values snippet:

  managedClusterGroups:
    exampleRegion:
      name: group-one
      acmlabels:
      - name: clusterGroup
        value: group-one
      helmOverrides:
      - name: clusterGroup.isHubCluster
        value: false
      clusterPools:
        exampleAWSPool:
          size: 1
          name: aws-ap-bandini
          openshiftVersion: 4.12.24
          baseDomain: blueprints.rhecoeng.com
          controlPlane:
            count: 1
            platform:
              aws:
                type: m5.2xlarge
          workers:
            count: 0
          platform:
            aws:
              region: ap-southeast-2
          clusters:
          - One

You will get a clusterClaim that is pointing to the wrong Pool:
NAMESPACE                 NAME                       POOL
open-cluster-management   one-group-one              aws-ap-bandini

This is wrong because the clusterPool name will be generated using the
pool name + "-" group name:

  {{- $pool := . }}
  {{- $poolName := print .name "-" $group.name }}

But the clusterPoolName inside the clusterName is only using the
"$pool.name" which will make the clusterClaim ineffective as the pool
does not exist.

Switch to using the same poolName that is being used when creating the
clusterPool.
