### PR TITLE
Error out from load-iib when INDEX_IMAGES is undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ load-iib: ## CI target to install Index Image Bundles
 		for IIB in $(shell echo $(INDEX_IMAGES) | tr ',' '\n'); do \
 			INDEX_IMAGE="$${IIB}" ansible-playbook common/ansible/playbooks/iib-ci/iib-ci.yaml; \
 		done; \
+	else \
+		echo "No INDEX_IMAGES defined. Bailing out"; \
+		exit 1; \
 	fi
 
 


### PR DESCRIPTION
If you call the load-iib target you *must* set INDEX_IMAGES, so
let's error out properly if you do not.
